### PR TITLE
Ordered materia melding

### DIFF
--- a/BisBuddy/Configuration.cs
+++ b/BisBuddy/Configuration.cs
@@ -28,6 +28,7 @@ public class Configuration : IPluginConfiguration
     public bool HighlightNeedGreed { get; set; } = true;
     public bool HighlightShops { get; set; } = true;
     public bool HighlightMateriaMeld { get; set; } = true;
+    public bool HighlightNextMateria { get; set; } = false;
     public bool HighlightInventories { get; set; } = true;
     public bool HighlightMarketboard { get; set; } = true;
     public bool AnnotateTooltips { get; set; } = true;

--- a/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
@@ -52,6 +52,9 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         // value for index of page selected (Gets overwritten when list element hovered/clicked)
         public static readonly int AtkValuePageIndexSelectedIndex = 4;
 
+        // for Next Materia behavior
+        private readonly Configuration configuration = plugin.Configuration;
+
         private string selectedItemName = string.Empty;
         private readonly HashSet<int> unmeldedItemIndexes = [];
         private readonly HashSet<int> neededMateriaIndexes = [];
@@ -163,15 +166,24 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 selectedMeldPlanIndex
                 );
 
+            // bad index
+            if (selectedMeldPlanIndex >= meldPlans.Count)
+            {
+                neededMateriaNames = [];
+                return;
+            }
+
             // update list of materia names that are needed
-            neededMateriaNames =
-                meldPlans.Count > selectedMeldPlanIndex
-                ? meldPlans[selectedMeldPlanIndex]
-                    .Materia
-                    .Where(m => !m.IsMelded)
-                    .Select(m => m.ItemName)
-                    .ToHashSet()
-                : [];
+            var materiaNames = meldPlans[selectedMeldPlanIndex]
+                .Materia
+                .Where(m => !m.IsMelded)
+                .Select(m => m.ItemName);
+
+            // limit to next materia to meld if configured
+            if (configuration.HighlightNextMateria)
+                materiaNames = materiaNames.Take(1);
+
+            neededMateriaNames = materiaNames.ToHashSet();
         }
 
         private unsafe bool updatePageIndex(AtkUnitBase* addon)

--- a/BisBuddy/Gear/Gearset.Util.cs
+++ b/BisBuddy/Gear/Gearset.Util.cs
@@ -54,15 +54,7 @@ namespace BisBuddy.Gear
 
                     // if there are any melds needed, add this 'meld plan' to the list
                     if (gearpieceMateria.Count > 0)
-                    {
-                        var meldPlan = new MeldPlan()
-                        {
-                            Gearset = gearset,
-                            Gearpiece = gearpiece,
-                            Materia = gearpieceMateria
-                        };
-                        neededMeldPlans.Add(meldPlan);
-                    }
+                        neededMeldPlans.Add(new MeldPlan(gearset, gearpiece, gearpieceMateria));
                 }
             }
 

--- a/BisBuddy/Gear/MeldPlan.cs
+++ b/BisBuddy/Gear/MeldPlan.cs
@@ -1,11 +1,42 @@
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BisBuddy.Gear
 {
-    public readonly struct MeldPlan
+    public readonly struct MeldPlan(Gearset gearset, Gearpiece gearpiece, List<Materia> materia)
     {
-        public Gearset Gearset { get; init; }
-        public Gearpiece Gearpiece { get; init; }
-        public List<Materia> Materia { get; init; }
+        // maximum length of gearset name for a plan
+        public static readonly int MaxMeldPlanNameLength = 30;
+        // string appended to unmelded materia in the meld plan
+        public static readonly string UnmeldedColorblindIndicator = "*";
+
+        public Gearset Gearset { get; init; } = gearset;
+        public Gearpiece Gearpiece { get; init; } = gearpiece;
+        public List<Materia> Materia { get; init; } = materia;
+        public string PlanText { get; init; } = BuildPlanText(gearset, gearpiece, materia);
+        public List<(string MateriaText, bool IsMelded)> MateriaInfo { get; init; } = BuildMateriaInfo(materia);
+
+        private static string BuildPlanText(Gearset gearset, Gearpiece gearpiece, List<Materia> materia)
+        {
+            var jobAbbrev = gearset.JobAbbrv;
+            var gearsetName = gearset.Name.Length > MaxMeldPlanNameLength
+                ? gearset.Name[..(MaxMeldPlanNameLength - 2)] + ".."
+                : gearset.Name;
+
+            return $"[{jobAbbrev}] {gearsetName}";
+        }
+
+        private static List<(string MateriaText, bool IsMelded)> BuildMateriaInfo(List<Materia> materia)
+        {
+            return materia
+                .OrderByDescending(m => m.StatQuantity)
+                .Select(m => (
+                    // MateriaText
+                    $"+{m.StatQuantity} {m.StatShortName}{(m.IsMelded ? "" : UnmeldedColorblindIndicator)}",
+                    // IsMelded
+                    m.IsMelded
+                    ))
+                .ToList();
+        }
     }
 }

--- a/BisBuddy/Plugin.Inventory.cs
+++ b/BisBuddy/Plugin.Inventory.cs
@@ -58,7 +58,7 @@ namespace BisBuddy
 
                     Services.Log.Debug($"Updated {updatedGearpieces.Count} gearpieces from inventories");
 
-                    if (updatedGearpieces.Count > 0 && saveChanges)
+                    if (saveChanges)
                     {
                         SaveGearsetsWithUpdate(false);
                     }

--- a/BisBuddy/Resources/Resource.Designer.cs
+++ b/BisBuddy/Resources/Resource.Designer.cs
@@ -352,6 +352,34 @@ namespace BisBuddy.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Next Materia Only.
+        /// </summary>
+        internal static string HighlightNextMateriaCheckbox {
+            get {
+                return ResourceManager.GetString("HighlightNextMateriaCheckbox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Whether to only highlight the next materia, or to highlight all available materia to meld. Useful for advanced melding
+        ///Note: Ensure no erroneous materia is already melded for most accurate highlighting
+        ///
+        ///When ON: All materia a gearpiece needs is highlighted in the melding window
+        ///When OFF: Only the next materia a gearpiece needs to meld is highlighted
+        ///
+        ///Example
+        ///Gearpiece needs the following melds: [+36 CRT, +36 DET]
+        ///
+        ///When ON: +36 CRT and +36 DET are highlighted
+        ///When OFF: +36 CRT is highlighted.
+        /// </summary>
+        internal static string HighlightNextMateriaHelp {
+            get {
+                return ResourceManager.GetString("HighlightNextMateriaHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Shops/Exchanges.
         /// </summary>
         internal static string HighlightShopExchangesCheckbox {

--- a/BisBuddy/Resources/Resource.resx
+++ b/BisBuddy/Resources/Resource.resx
@@ -376,4 +376,20 @@ ex:
   <data name="GearsetStringTooltip" xml:space="preserve">
     <value>Copy {0} text to clipboard</value>
   </data>
+  <data name="HighlightNextMateriaCheckbox" xml:space="preserve">
+    <value>Next Materia Only</value>
+  </data>
+  <data name="HighlightNextMateriaHelp" xml:space="preserve">
+    <value>Whether to only highlight the next materia, or to highlight all available materia to meld. Useful for advanced melding
+Note: Ensure no erroneous materia is already melded for most accurate highlighting
+
+When ON: All materia a gearpiece needs is highlighted in the melding window
+When OFF: Only the next materia a gearpiece needs to meld is highlighted
+
+Example
+Gearpiece needs the following melds: [+36 CRT, +36 DET]
+
+When ON: +36 CRT and +36 DET are highlighted
+When OFF: +36 CRT is highlighted</value>
+  </data>
 </root>

--- a/BisBuddy/Windows/ConfigWindow.cs
+++ b/BisBuddy/Windows/ConfigWindow.cs
@@ -92,6 +92,7 @@ public class ConfigWindow : Window, IDisposable
         ImGuiComponents.HelpMarker(Resource.HighlightShopExchangesHelp);
 
         // MATERIA MELDING
+        // toggle highlighting
         var highlightMateriaMeld = configuration.HighlightMateriaMeld;
         if (ImGui.Checkbox(Resource.HighlightMateriaMeldingCheckbox, ref highlightMateriaMeld))
         {
@@ -101,6 +102,30 @@ public class ConfigWindow : Window, IDisposable
         }
         ImGui.SameLine();
         ImGuiComponents.HelpMarker(Resource.HighlightMateriaMeldingHelp);
+
+        // next materia vs all materia
+        using (ImRaii.Disabled(!highlightMateriaMeld))
+        {
+            // draw a L shape for parent-child relationship
+            var drawList = ImGui.GetWindowDrawList();
+            var curLoc = ImGui.GetCursorScreenPos();
+            var col = ImGui.GetColorU32(new Vector4(1, 1, 1, 1));
+            var halfButtonHeight = (ImGui.CalcTextSize("HI").Y / 2) + ImGui.GetStyle().FramePadding.Y;
+            drawList.AddLine(curLoc + new Vector2(10, 0), curLoc + new Vector2(10, halfButtonHeight), col, 2);
+            drawList.AddLine(curLoc + new Vector2(10, halfButtonHeight), curLoc + new Vector2(20, halfButtonHeight), col, 2);
+
+            using (ImRaii.PushIndent(25.0f, scaled: false))
+            {
+                var highlightNextMateria = configuration.HighlightNextMateria;
+                if (ImGui.Checkbox(Resource.HighlightNextMateriaCheckbox, ref highlightNextMateria))
+                {
+                    configuration.HighlightNextMateria = highlightNextMateria;
+                    plugin.SaveGearsetsWithUpdate(false);
+                }
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(Resource.HighlightNextMateriaHelp);
+            }
+        }
 
         // INVENTORIES
         var highlightInventories = configuration.HighlightInventories;

--- a/BisBuddy/Windows/MainWindow.cs
+++ b/BisBuddy/Windows/MainWindow.cs
@@ -18,8 +18,8 @@ public partial class MainWindow : Window, IDisposable
     public bool InventoryScanRunning = false;
     public int InventoryScanUpdateCount = -1;
 
-    private static Vector4 UnobtainedColor = new(1.0f, 0.2f, 0.2f, 1.0f);
-    private static Vector4 ObtainedColor = new(0.2f, 1.0f, 0.2f, 1.0f);
+    public static readonly Vector4 UnobtainedColor = new(1.0f, 0.2f, 0.2f, 1.0f);
+    public static readonly Vector4 ObtainedColor = new(0.2f, 1.0f, 0.2f, 1.0f);
 
     public MainWindow(Plugin plugin)
         : base($"{Plugin.PluginName}##bisbuddymainwindow")

--- a/BisBuddy/Windows/MeldPlanSelectorWindow.cs
+++ b/BisBuddy/Windows/MeldPlanSelectorWindow.cs
@@ -2,20 +2,18 @@ using BisBuddy.Gear;
 using BisBuddy.Resources;
 using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility;
+using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using ImGuiNET;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 using System.Numerics;
 
 namespace BisBuddy.Windows;
 
 public unsafe class MeldPlanSelectorWindow : Window, IDisposable
 {
-    // maximum length of gearset name for a plan
-    public static readonly int MaxMeldPlanNameLength = 30;
     // how far down from the top of the addon to render the window
     private static readonly int WindowYValueOffset = 76;
 
@@ -29,32 +27,13 @@ public unsafe class MeldPlanSelectorWindow : Window, IDisposable
         Flags = ImGuiWindowFlags.NoResize | ImGuiWindowFlags.NoCollapse | ImGuiWindowFlags.NoScrollbar |
                 ImGuiWindowFlags.NoScrollWithMouse | ImGuiWindowFlags.NoTitleBar | ImGuiWindowFlags.AlwaysAutoResize;
 
+        SizeCondition = ImGuiCond.Appearing;
+
         configuration = plugin.Configuration;
         this.plugin = plugin;
     }
 
     public void Dispose() { }
-
-    private List<string> getPopupNames()
-    {
-        List<string> newPlanNames = [];
-        var colorblindIndicator = "*";
-
-        foreach (var plan in MeldPlans)
-        {
-            var jobAbbrev = plan.Gearset.JobAbbrv;
-            var gearsetName = plan.Gearset.Name.Length > MaxMeldPlanNameLength
-                ? plan.Gearset.Name[..(MaxMeldPlanNameLength - 2)] + ".."
-                : plan.Gearset.Name;
-            var materiaAbbrevs = plan
-                .Materia
-                .OrderByDescending(m => m.StatQuantity)
-                .Select(m => $"+{m.StatQuantity} {m.StatShortName}{(m.IsMelded ? "" : colorblindIndicator)}");
-            newPlanNames.Add($"[{jobAbbrev}] {gearsetName}\n[{string.Join(" ", materiaAbbrevs)}]");
-        }
-
-        return newPlanNames;
-    }
 
     public override void PreDraw()
     {
@@ -112,16 +91,44 @@ public unsafe class MeldPlanSelectorWindow : Window, IDisposable
         ImGui.Separator();
         ImGui.Spacing();
 
-        var planNames = getPopupNames();
-
-        for (var i = 0; i < planNames.Count; i++)
+        for (var i = 0; i < MeldPlans.Count; i++)
         {
+            using var _ = ImRaii.PushId(i);
+            var plan = MeldPlans[i];
+
             var isSelected = plugin.MateriaAttachEventListener.selectedMeldPlanIndex == i;
-            if (ImGui.Selectable($"{planNames[i]}##{i}", isSelected))
+            var planSelectableSize = new Vector2(
+                ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X,
+                ImGui.CalcTextSize("HI\nHI").Y + ImGui.GetStyle().FramePadding.Y   // two lines
+                );
+
+            var selectablePos = ImGui.GetCursorPos();
+
+            if (ImGui.Selectable($" \n ###materia_plan_selectable", isSelected, ImGuiSelectableFlags.SpanAllColumns))
             {
                 plugin.TriggerSelectedMeldPlanChange(i);
                 Services.Log.Debug($"Selected meld plan {i}");
             }
+
+            // Overlap plan text with empty selectable
+            ImGui.SetCursorPos(selectablePos);
+
+            // reduce vertical space between plan text and materia
+            using (ImRaii.PushStyle(ImGuiStyleVar.ItemSpacing, new Vector2(0, 0)))
+            {
+                // add left spacing
+                ImGui.Text($" {plan.PlanText}");
+                ImGui.Text($" ");
+                ImGui.SameLine();
+            }
+
+            foreach (var materia in plan.MateriaInfo)
+            {
+                var color = materia.IsMelded ? MainWindow.ObtainedColor : MainWindow.UnobtainedColor;
+                ImGui.TextColored(color, materia.MateriaText);
+                ImGui.SameLine();
+            }
+            ImGui.NewLine();
         }
     }
 }

--- a/BisBuddy/Windows/MeldPlanSelectorWindow.cs
+++ b/BisBuddy/Windows/MeldPlanSelectorWindow.cs
@@ -1,5 +1,6 @@
 using BisBuddy.Gear;
 using BisBuddy.Resources;
+using Dalamud.Interface.Components;
 using Dalamud.Interface.Utility;
 using Dalamud.Interface.Windowing;
 using FFXIVClientStructs.FFXIV.Component.GUI;
@@ -16,7 +17,7 @@ public unsafe class MeldPlanSelectorWindow : Window, IDisposable
     // maximum length of gearset name for a plan
     public static readonly int MaxMeldPlanNameLength = 30;
     // how far down from the top of the addon to render the window
-    private static readonly int WindowYValueOffset = 102;
+    private static readonly int WindowYValueOffset = 76;
 
     private readonly Configuration configuration;
     private readonly Plugin plugin;
@@ -97,6 +98,17 @@ public unsafe class MeldPlanSelectorWindow : Window, IDisposable
         if (curIdx >= MeldPlans.Count) return;
 
         ImGui.Text(Resource.MeldWindowHeader);
+
+        // copy next materia setting from config for convenience
+        var highlightNextMateria = configuration.HighlightNextMateria;
+        if (ImGui.Checkbox(Resource.HighlightNextMateriaCheckbox, ref highlightNextMateria))
+        {
+            configuration.HighlightNextMateria = highlightNextMateria;
+            plugin.SaveGearsetsWithUpdate(false);
+        }
+        ImGui.SameLine();
+        ImGuiComponents.HelpMarker(Resource.HighlightNextMateriaHelp);
+
         ImGui.Separator();
         ImGui.Spacing();
 

--- a/BisBuddy/Windows/MeldPlanSelectorWindow.cs
+++ b/BisBuddy/Windows/MeldPlanSelectorWindow.cs
@@ -96,14 +96,9 @@ public unsafe class MeldPlanSelectorWindow : Window, IDisposable
             using var _ = ImRaii.PushId(i);
             var plan = MeldPlans[i];
 
-            var isSelected = plugin.MateriaAttachEventListener.selectedMeldPlanIndex == i;
-            var planSelectableSize = new Vector2(
-                ImGui.GetWindowContentRegionMax().X - ImGui.GetWindowContentRegionMin().X,
-                ImGui.CalcTextSize("HI\nHI").Y + ImGui.GetStyle().FramePadding.Y   // two lines
-                );
-
             var selectablePos = ImGui.GetCursorPos();
 
+            var isSelected = plugin.MateriaAttachEventListener.selectedMeldPlanIndex == i;
             if (ImGui.Selectable($" \n ###materia_plan_selectable", isSelected, ImGuiSelectableFlags.SpanAllColumns))
             {
                 plugin.TriggerSelectedMeldPlanChange(i);


### PR DESCRIPTION
- Added `Next Materia Only` config option, disabled by default
  - When enabled, will only highlight the first unmelded materia for the gearpiece/meld plan
  - Added to config window and the meld plan selector window for ease of use
- Render materia on meld plan selector window with color to indicate if they are melded or not
- Fix bug where updating melded materia with an inventory update would not send a event to refresh addon event listeners