### PR TITLE
add game data parsing for unknown coffer contents

### DIFF
--- a/BisBuddy/BisBuddy.csproj
+++ b/BisBuddy/BisBuddy.csproj
@@ -12,6 +12,7 @@
   </PropertyGroup>
 
   <ItemGroup>
+    <PackageReference Include="Fastenshtein" Version="1.0.10" />
     <PackageReference Include="LinearAssignment" Version="1.2.0" />
     <PackageReference Include="Lumina" Version="5.6.1" />
     <PackageReference Include="Lumina.Excel" Version="7.2.0" />

--- a/BisBuddy/Items/ItemData.Generate.cs
+++ b/BisBuddy/Items/ItemData.Generate.cs
@@ -1,3 +1,4 @@
+using Dalamud.Utility;
 using Lumina.Excel;
 using Lumina.Excel.Sheets;
 using LuminaSupplemental.Excel.Model;
@@ -5,6 +6,7 @@ using LuminaSupplemental.Excel.Services;
 using System;
 using System.Collections.Generic;
 using System.Linq;
+using System.Text.RegularExpressions;
 
 namespace BisBuddy.Items
 {
@@ -16,6 +18,29 @@ namespace BisBuddy.Items
         // Max cost item quantity is limited to limit size of graph for assignment
         private static readonly int MaxCostQuantity = 20;
 
+        // map of coffer item.Icon => item.ItemUiCategory.RowId
+        private static readonly Dictionary<ushort, List<uint>> CofferIconToEquipSlotCategory = new()
+        {
+            { 26557, [1, 2, 13] }, // general weapon coffer
+            { 26632, [1, 2] },     // PLD arms 1
+            { 26633, [1, 2] },     // PLD arms 2
+            { 26634, [1, 2] },     // PLD arms 3
+            { 26635, [1, 2] },     // PLD arms 4
+            { 26558, [3] },        // head
+            { 26559, [4] },        // body
+            { 26560, [5] },        // gloves
+            { 26561, [7] },        // pants
+            { 26562, [8] },        // shoes
+            // { 26573, [6] }        // belt/waist, ignore
+            { 26564, [9] },        // earrings
+            { 26565, [10] },       // necklace
+            { 26566, [11] },       // bracelet
+            { 26567, [12] },       // ring
+        };
+
+        private static readonly Regex ItemNameIlvlRegex = new(@"\(IL ([0-9]*)\)");
+        private static readonly Regex AugmentedTomestoneGearNameRegex = new(@"\AAugmented");
+
         private static List<SpecialShop> getRelevantShops(ExcelSheet<SpecialShop> shopSheet)
         {
             var shops = new List<SpecialShop>();
@@ -26,7 +51,104 @@ namespace BisBuddy.Items
             return shops;
         }
 
-        private static ILookup<uint, uint> generateItemsCoffers()
+        /// <summary>
+        /// Scrape game data to try and find matches for coffers that don't yet exist in LuminaSupplemental due to Eorzea Database not updating
+        /// to contain them yet. Adds any it finds to existing ItemSupplement list
+        /// </summary>
+        /// <param name="existingCofferSources">List of existing loot supplement relations</param>
+        /// <param name="itemSheet">The game itemSheet</param>
+        private static void addNewCoffers(List<ItemSupplement> existingCofferSources, ExcelSheet<Item> itemSheet)
+        {
+            // list of ids of coffer-like items with known contents
+            var knownCoffers = existingCofferSources
+                .Select(item => item.SourceItemId)
+                .ToHashSet();
+
+            // get list of coffer-like items with unknown contents
+            var unknownCoffers = new HashSet<Item>();
+            var unknownCofferIlvls = new HashSet<uint>();
+            var candidateItems = new Dictionary<uint, List<Item>>();
+            var candidateCoffers = new Dictionary<uint, List<Item>>();
+            foreach (var item in itemSheet.Where(item => !knownCoffers.Contains(item.RowId)))
+            {
+                var itemName = item.Name.ToDalamudString().TextValue;
+                if (CofferIconToEquipSlotCategory.ContainsKey(item.Icon))
+                {
+                    var match = ItemNameIlvlRegex.Match(itemName);
+                    if (!match.Success)
+                        continue;
+
+                    var itemLevel = uint.Parse(match.Groups[1].Value);
+                    unknownCoffers.Add(item);
+                    unknownCofferIlvls.Add(itemLevel);
+                    candidateItems[itemLevel] = [];
+                    if (!candidateCoffers.TryGetValue(itemLevel, out var coffersAtIlvl))
+                        candidateCoffers[itemLevel] = [item];
+                    else
+                        coffersAtIlvl.Add(item);
+                }
+            }
+
+            // no coffers with unknown contents
+            if (unknownCoffers.Count == 0)
+                return;
+
+            // retrieve items that may feasibly come from unknown coffers
+            foreach (var item in itemSheet)
+            {
+                // a coffer, ignore
+                if (unknownCoffers.Contains(item) || knownCoffers.Contains(item.RowId))
+                    continue;
+
+                // cannot be equipped, not a gearpiece
+                if (item.EquipSlotCategory.RowId == 0)
+                    continue;
+
+                // this is a augmented tomestone gearpiece, cannot be from coffer
+                var itemName = item.Name.ToDalamudString().TextValue;
+                if (AugmentedTomestoneGearNameRegex.IsMatch(itemName))
+                    continue;
+
+                // potential candidate item
+                if (unknownCofferIlvls.Contains(item.LevelItem.RowId))
+                    candidateItems[item.LevelItem.RowId].Add(item);
+            }
+
+            // solve per relevant ilvl
+            foreach (var ilvl in unknownCofferIlvls)
+            {
+                var coffersAtIlvl = candidateCoffers[ilvl];
+                var itemsAtIlvl = candidateItems[ilvl];
+                // group items by EquipSlotCategory/ClassJobCategory pair, since cannot contain multiple from each grouping from 1 coffer
+                var groupedItemsAtIlvl = itemsAtIlvl
+                    .GroupBy(
+                        item => new 
+                        { 
+                            equipSlotCategory = item.EquipSlotCategory.RowId,
+                            classJobCategory = item.ClassJobCategory.RowId,
+                        });
+
+                foreach (var coffer in coffersAtIlvl)
+                {
+                    var cofferName = coffer.Name.ToDalamudString().TextValue;
+                    var cofferNameLev = new Fastenshtein.Levenshtein(cofferName);
+                    var cofferEquipSlot = CofferIconToEquipSlotCategory.GetValueOrDefault(coffer.Icon) ?? [];
+
+                    foreach (var itemGroup in groupedItemsAtIlvl.Where(g => cofferEquipSlot.Contains(g.Key.equipSlotCategory)))
+                    {
+                        // get item whos name most closely matches name of coffer
+                        var bestMatch = itemGroup
+                            .OrderBy(item => cofferNameLev.DistanceFrom(item.Name.ToDalamudString().TextValue))
+                            .First();
+
+                        var newItemSupplement = new ItemSupplement(bestMatch.RowId, coffer.RowId, ItemSupplementSource.Loot);
+                        existingCofferSources.Add(newItemSupplement);
+                    }
+                }
+            }
+        }
+
+        private static ILookup<uint, uint> generateItemsCoffers(ExcelSheet<Item> itemSheet)
         {
             try
             {
@@ -38,6 +160,7 @@ namespace BisBuddy.Items
                     Services.DataManager.GameData,
                     Services.DataManager.GameData.Options.DefaultExcelLanguage
                     );
+
                 if (failedLines.Count != 0)
                 {
                     foreach (var failedLine in failedLines)
@@ -46,14 +169,19 @@ namespace BisBuddy.Items
                     }
                 }
 
-                return lines
+                var cofferLines = lines
                     .Where(item => item.ItemSupplementSource == ItemSupplementSource.Loot)
+                    .ToList();
+
+                // use game data to try and parse new coffers that don't exist in pulled data
+                addNewCoffers(cofferLines, itemSheet);
+
+                return cofferLines
                     .ToLookup(i => i.ItemId, i => i.SourceItemId);
             }
-            catch (Exception e)
+            catch (Exception ex)
             {
-                Services.Log.Error("Failed to generate coffers using " + CsvLoader.ItemSupplementResourceName);
-                Services.Log.Error(e.Message);
+                Services.Log.Error(ex, "Failed to generate coffers using " + CsvLoader.ItemSupplementResourceName);
                 throw;
             }
         }

--- a/BisBuddy/Items/ItemData.cs
+++ b/BisBuddy/Items/ItemData.cs
@@ -32,7 +32,7 @@ namespace BisBuddy.Items
             {
                 if (itemsCoffers == null)
                 {
-                    itemsCoffers = generateItemsCoffers();
+                    itemsCoffers = generateItemsCoffers(ItemSheet);
                     Task.Run(async () =>
                     {
                         await Task.Delay(3000);

--- a/BisBuddy/packages.lock.json
+++ b/BisBuddy/packages.lock.json
@@ -14,6 +14,12 @@
         "resolved": "1.2.25",
         "contentHash": "xCXiw7BCxHJ8pF6wPepRUddlh2dlQlbr81gXA72hdk4FLHkKXas7EH/n+fk5UCA/YfMqG1Z6XaPiUjDbUNBUzg=="
       },
+      "Fastenshtein": {
+        "type": "Direct",
+        "requested": "[1.0.10, )",
+        "resolved": "1.0.10",
+        "contentHash": "fZ5DKypgdTkwfchV4fZ5OFFGYu49B8YbUMr6hN6Azl7IziIsyKARqdU3EZt/oQJyV71eQxpY9jL2J1tXb2gvlQ=="
+      },
       "LinearAssignment": {
         "type": "Direct",
         "requested": "[1.2.0, )",


### PR DESCRIPTION
Lodestone page doesn't contain all item/coffer data on release (anti-spoiler maybe?). Add back some game data parsing to determine best guess at the contents of coffers not yet in the LuminaSupplemental sheet.