### PR TITLE
Atk management with kamitoolkit

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,0 +1,3 @@
+[submodule "KamiToolKit"]
+	path = KamiToolKit
+	url = https://github.com/MidoriKami/KamiToolKit.git

--- a/BisBuddy.sln
+++ b/BisBuddy.sln
@@ -5,6 +5,8 @@ VisualStudioVersion = 17.11.35222.181
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{9A19103F-16F7-4668-BE54-9A1E7A4F7556}") = "BisBuddy", "BisBuddy\BisBuddy.csproj", "{54988682-ABAC-49DB-B807-2C28BB4C34C4}"
 EndProject
+Project("{FAE04EC0-301F-11D3-BF4B-00C04F79EFBC}") = "KamiToolKit", "KamiToolKit\KamiToolKit.csproj", "{63CBC071-46BC-406C-833D-DBFD80FE4A9B}"
+EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|x64 = Debug|x64
@@ -15,6 +17,10 @@ Global
 		{54988682-ABAC-49DB-B807-2C28BB4C34C4}.Debug|x64.Build.0 = Debug|x64
 		{54988682-ABAC-49DB-B807-2C28BB4C34C4}.Release|x64.ActiveCfg = Release|x64
 		{54988682-ABAC-49DB-B807-2C28BB4C34C4}.Release|x64.Build.0 = Release|x64
+		{63CBC071-46BC-406C-833D-DBFD80FE4A9B}.Debug|x64.ActiveCfg = Debug|x64
+		{63CBC071-46BC-406C-833D-DBFD80FE4A9B}.Debug|x64.Build.0 = Debug|x64
+		{63CBC071-46BC-406C-833D-DBFD80FE4A9B}.Release|x64.ActiveCfg = Release|x64
+		{63CBC071-46BC-406C-833D-DBFD80FE4A9B}.Release|x64.Build.0 = Release|x64
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE

--- a/BisBuddy/BisBuddy.csproj
+++ b/BisBuddy/BisBuddy.csproj
@@ -34,4 +34,8 @@
       <CopyToOutputDirectory>PreserveNewest</CopyToOutputDirectory>
     </EmbeddedResource>
   </ItemGroup>
+
+  <ItemGroup>
+    <ProjectReference Include="..\KamiToolKit\KamiToolKit.csproj" />
+  </ItemGroup>
 </Project>

--- a/BisBuddy/Configuration.cs
+++ b/BisBuddy/Configuration.cs
@@ -41,6 +41,14 @@ public class Configuration : IPluginConfiguration
     // normal nodes: (0, 100, 0)
     // custom nodes: (-255, 255, -255)
     public Vector4 HighlightColor { get; set; } = new Vector4(0.0f, 1.0f, 0.0f, 0.392f);
+    // scale between -1.0f and 1.0f. (ex: 0.0f -> -1.0f, 0.5f -> 0.0f, 1.0f -> 1.0f)
+    public Vector3 CustomNodeAddColor => new(
+        (HighlightColor.X * 2) - 1,
+        (HighlightColor.Y * 2) - 1,
+        (HighlightColor.Z * 2) - 1
+        );
+    public readonly float CustomNodeAlpha = 1.0f;
+    public readonly Vector3 CustomNodeMultiplyColor = new(0.393f, 0.393f, 0.393f);
 
     public Dictionary<ulong, CharacterInfo> CharactersData { get; set; } = [];
 

--- a/BisBuddy/EventListeners/AddonEventListeners/AddonEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/AddonEventListener.cs
@@ -136,8 +136,9 @@ namespace BisBuddy.EventListeners.AddonEventListeners
 
             allNodesUnmarked &= !toEnable; // if any node is enabled, at least one node is marked
 
-            customNode.AddColor = Plugin.Configuration.CustomNodeAddColor;
-            customNode.Alpha = Plugin.Configuration.CustomNodeAlpha;
+            if (customNode.IsVisible == toEnable)
+                return false;
+
             customNode.IsVisible = toEnable;
             return true;
         }

--- a/BisBuddy/EventListeners/AddonEventListeners/Containers/ContainerEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/Containers/ContainerEventListener.cs
@@ -5,6 +5,7 @@ using Dalamud.Game.Inventory;
 using FFXIVClientStructs.FFXIV.Client.Game;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using KamiToolKit.Nodes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -250,15 +251,15 @@ namespace BisBuddy.EventListeners.AddonEventListeners.Containers
             return container->GetInventorySlot(item->Slot);
         }
 
-        protected override nint initializeCustomNode(nint parentNodePtr)
+        protected override unsafe NodeBase? initializeCustomNode(AtkResNode* parentNodePtr, AtkUnitBase* addon)
         {
             // doesn't use custom nodes
-            return nint.Zero;
+            return null;
         }
 
-        protected override void unlinkCustomNode(nint nodePtr)
+        protected override void unlinkCustomNode(nint parentNodePtr, NodeBase node)
         {
-            // no nodes to unlink
+            // doesn't use custom nodes
             return;
         }
     }

--- a/BisBuddy/EventListeners/AddonEventListeners/ItemSearchResultEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ItemSearchResultEventListener.cs
@@ -5,6 +5,8 @@ using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using KamiToolKit.Classes;
+using KamiToolKit.Nodes;
 using System;
 
 namespace BisBuddy.EventListeners.AddonEventListeners
@@ -195,37 +197,54 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             }
         }
 
-        protected override unsafe nint initializeCustomNode(nint parentNodePtr)
+        protected override unsafe NodeBase? initializeCustomNode(AtkResNode* parentNodePtr, AtkUnitBase* addon)
         {
-            AtkNineGridNode* customHighlightNode = null;
+            NineGridNode? customNode = null;
             try
             {
                 var parentNode = (AtkComponentNode*)parentNodePtr;
-                var hoverNode = ((AtkComponentNode*)parentNodePtr)
+
+                var hoverNode = parentNode
                     ->GetComponent()
                     ->UldManager
                     .SearchNodeById(AddonHoverHighlightNodeId)
                     ->GetAsAtkNineGridNode();
-                customHighlightNode = UiHelper.CloneNineGridNode(AddonCustomNodeId, hoverNode);
-                customHighlightNode->SetAlpha(255);
-                customHighlightNode->DrawFlags |= 0x01; // force a redraw ("dirty flag")
-                UiHelper.LinkNodeAfterTargetNode((AtkResNode*)customHighlightNode, parentNode, (AtkResNode*)hoverNode);
 
-                return (nint)customHighlightNode;
+                customNode = UiHelper.CloneNineGridNode(
+                    AddonCustomNodeId,
+                    hoverNode,
+                    Plugin.Configuration.CustomNodeAddColor,
+                    Plugin.Configuration.CustomNodeMultiplyColor,
+                    Plugin.Configuration.CustomNodeAlpha
+                    ) ?? throw new Exception($"Could not clone node \"{hoverNode->NodeId}\"");
+
+                // mark as dirty
+                customNode.InternalNode->DrawFlags |= 0x1;
+
+                // attach it to the addon
+                Services.NativeController.AttachToComponent(customNode, addon, parentNode->Component, (AtkResNode*)hoverNode, NodePosition.BeforeTarget);
+
+                return customNode;
             }
             catch (Exception ex)
             {
-                if (customHighlightNode != null) UiHelper.FreeNineGridNode(customHighlightNode);
+                customNode?.Dispose();
                 Services.Log.Error(ex, "Failed to initialize custom node");
-                return nint.Zero;
+                return null;
             }
         }
-        protected override unsafe void unlinkCustomNode(nint nodePtr)
-        {
-            var node = (AtkResNode*)nodePtr;
-            if (node->ParentNode == null) return; // node isn't linked, nothing to unlink
 
-            UiHelper.UnlinkNode(node, (AtkComponentNode*)node->ParentNode);
+        protected override unsafe void unlinkCustomNode(nint parentNodePtr, NodeBase node)
+        {
+            var addon = Services.GameGui.GetAddonByName(AddonName);
+
+            if (addon == nint.Zero)
+                return;
+
+            if (parentNodePtr == nint.Zero)
+                return;
+
+            Services.NativeController.DetachFromComponent(node, (AtkUnitBase*)addon, ((AtkComponentNode*)parentNodePtr)->Component);
         }
     }
 }

--- a/BisBuddy/EventListeners/AddonEventListeners/ItemSearchResultEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ItemSearchResultEventListener.cs
@@ -2,12 +2,16 @@ using BisBuddy.Gear;
 using BisBuddy.Util;
 using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
+using Dalamud.Utility;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Client.UI.Info;
 using FFXIVClientStructs.FFXIV.Component.GUI;
 using KamiToolKit.Classes;
 using KamiToolKit.Nodes;
 using System;
+using System.Collections.Generic;
+using System.Linq;
+using static FFXIVClientStructs.FFXIV.Component.GUI.AtkComponentList;
 
 namespace BisBuddy.EventListeners.AddonEventListeners
 {
@@ -28,11 +32,13 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         public static readonly uint AddonItemScrollbarNodeId = 5;
         // id of the scroll button on the bar
         public static readonly uint AddonItemScrollButtonNodeId = 2;
+        // id of the text node containing the quantity of the item being sold in the result
+        public static readonly uint AddonItemQuantityNodeId = 6;
 
 
         // if nq or hq is needed for the selected item
-        private bool nqNeeded = false;
-        private bool hqNeeded = false;
+        private int nqNeeded = 0;
+        private int hqNeeded = 0;
         // the previous Y value of the scrollbar
         private float previousScrollbarY = -1.0f;
 
@@ -72,15 +78,20 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         {
             try
             {
-                if (!hqNeeded && !nqNeeded)
+                if (hqNeeded == 0 && nqNeeded == 0)
                 { // no variant needed for this selection, unmark and quit
                     unmarkAllNodes();
                     return;
                 };
                 var addon = (AddonItemSearchResult*)Services.GameGui.GetAddonByName(AddonName);
-                if (addon == null || !addon->IsVisible) return; // addon not visible/rendered
 
-                if (addon->Results == null || addon->Results->ListLength == 0) return; // no items for sale
+                // addon not visible/rendered
+                if (addon == null || !addon->IsVisible)
+                    return;
+
+                // no items for sale
+                if (addon->Results == null || addon->Results->ListLength == 0)
+                    return;
 
                 var listingList = addon->Results;
 
@@ -98,72 +109,73 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 else
                 {
                     // scrollbar in same position, nodes haven't changed
-                    if (scrollbarNode->Y == previousScrollbarY) return;
+                    if (scrollbarNode->Y == previousScrollbarY)
+                        return;
 
                     previousScrollbarY = scrollbarNode->Y;
                 }
 
-                //var nqMarked = false;
-                //var hqMarked = false;
+                var listings = new List<ListItem>();
+
                 var firstListItemIndex = 0;
-
-                AtkComponentListItemRenderer* nqItemToMark = null;
-                AtkComponentListItemRenderer* hqItemToMark = null;
-
                 for (var i = 0; i < listingList->ListLength; i++)
                 {
                     var listItem = listingList->ItemRendererList[i];
                     var listItemIndex = listItem.AtkComponentListItemRenderer->ListItemIndex;
 
-                    if (i == 0) firstListItemIndex = listItemIndex;
+                    if (i == 0)
+                        firstListItemIndex = listItemIndex;
+                    // display list has "looped back" to the beginning (too many items to display), break out
                     else if (listItemIndex == firstListItemIndex)
-                    {
-                        // display list has "looped back" to the beginning (too many items to display), break out
                         break;
-                    }
 
-                    var itemQualityImageNode = (AtkTextNode*)listItem.AtkComponentListItemRenderer->GetImageNodeById(AddonItemQualityImageNodeId);
-                    if (itemQualityImageNode == null) continue;
+                    listings.Add(listItem);
+                }
+
+                // sort such that first list item at beginning
+                listings = listings
+                    .OrderBy(item => item.AtkComponentListItemRenderer->ListItemIndex)
+                    .ToList();
+
+                var nqNeededRem = nqNeeded;
+                var hqNeededRem = hqNeeded;
+                foreach (var listItem in listings)
+                {
+                    var itemQualityImageNode = listItem.AtkComponentListItemRenderer->GetImageNodeById(AddonItemQualityImageNodeId);
+                    if (itemQualityImageNode == null)
+                        continue;
 
                     var itemIsHq = itemQualityImageNode->IsVisible();
 
+                    var listingNode = (AtkResNode*)listItem.AtkComponentListItemRenderer->OwnerNode;
 
-                    if (nqNeeded && !itemIsHq && (nqItemToMark == null || listItemIndex < nqItemToMark->ListItemIndex)) // needed hq
+                    if (nqNeededRem > 0 && !itemIsHq) // needed nq
                     {
-                        // unmark old candidate
-                        if (nqItemToMark != null)
-                        {
-                            setNodeNeededMark((AtkResNode*)nqItemToMark->OwnerNode, false, true, true);
-                        }
-                        // set as new candidate
-                        nqItemToMark = listItem.AtkComponentListItemRenderer;
+                        // mark the node
+                        setNodeNeededMark(listingNode, true, true, true);
 
+                        // subtract the node's listing quantity from the remaining needed quantity
+                        var listingQuantityNode = (AtkTextNode*)listItem.AtkComponentListItemRenderer->GetTextNodeById(AddonItemQuantityNodeId);
+                        var listingQuantity = int.TryParse(listingQuantityNode->GetText().AsDalamudSeString().TextValue, out var parseResult)
+                            ? parseResult
+                            : 0;
+
+                        nqNeededRem -= listingQuantity;
                     }
-                    else if (hqNeeded && itemIsHq && (hqItemToMark == null || listItemIndex < hqItemToMark->ListItemIndex)) // needed nq
+                    else if (hqNeededRem > 0 && itemIsHq) // needed hq
                     {
-                        // unmark old candidate
-                        if (hqItemToMark != null)
-                        {
-                            setNodeNeededMark((AtkResNode*)hqItemToMark->OwnerNode, false, true, true);
-                        }
-                        // set as new candidate
-                        hqItemToMark = listItem.AtkComponentListItemRenderer;
+                        // mark the node
+                        setNodeNeededMark(listingNode, true, true, true);
 
+                        // subtract the node's listing quantity from the remaining needed quantity
+                        var listingQuantityNode = (AtkTextNode*)listingNode->GetComponent()->GetTextNodeById(AddonItemQuantityNodeId);
+                        var listingQuantity = int.TryParse(listingQuantityNode->GetText().AsDalamudSeString().TextValue, out var parseResult)
+                            ? parseResult
+                            : 0;
+                        hqNeededRem -= listingQuantity;
                     }
                     else // unneeded
-                    {
-                        setNodeNeededMark((AtkResNode*)listItem.AtkComponentListItemRenderer->OwnerNode, false, true, true);
-                    }
-                }
-
-                // mark final candidate items
-                if (nqItemToMark != null)
-                {
-                    setNodeNeededMark((AtkResNode*)nqItemToMark->OwnerNode, true, true, true);
-                }
-                if (hqItemToMark != null)
-                {
-                    setNodeNeededMark((AtkResNode*)hqItemToMark->OwnerNode, true, true, true);
+                        setNodeNeededMark(listingNode, false, true, true);
                 }
             }
             catch (Exception ex)
@@ -176,8 +188,8 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         {
             try
             {
-                nqNeeded = false;
-                hqNeeded = false;
+                nqNeeded = 0;
+                hqNeeded = 0;
                 var infoProxy = InfoProxyItemSearch.Instance();
 
                 if (infoProxy == null) return;
@@ -185,8 +197,10 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 var nqItemId = infoProxy->SearchItemId;
                 var hqItemId = Plugin.ItemData.ConvertItemIdToHq(nqItemId);
 
-                nqNeeded = Gearset.GetGearsetsNeedingItemById(nqItemId, Plugin.Gearsets).Count > 0;
-                hqNeeded = hqItemId != nqItemId && Gearset.GetGearsetsNeedingItemById(hqItemId, Plugin.Gearsets).Count > 0;
+                nqNeeded = Gearset.GetGearsetsNeedingItemById(nqItemId, Plugin.Gearsets).Sum(gearset => gearset.countNeeded);
+                hqNeeded = hqItemId != nqItemId
+                    ? Gearset.GetGearsetsNeedingItemById(hqItemId, Plugin.Gearsets).Sum(gearset => gearset.countNeeded)
+                    : 0;
 
                 // ensure this update refreshes the draws by resetting caches
                 previousScrollbarY = -1.0f;

--- a/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
@@ -4,6 +4,8 @@ using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.Text.SeStringHandling;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using KamiToolKit.Classes;
+using KamiToolKit.Nodes;
 using System;
 using System.Collections.Generic;
 using System.Linq;
@@ -404,13 +406,13 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             {
                 var itemNodeComponent = parentNodeComponent->ItemRendererList[i].AtkComponentListItemRenderer;
                 var itemNeeded = highlightedIndexList.Contains(itemNodeComponent->ListItemIndex);
-                setNodeNeededMark((AtkResNode*)itemNodeComponent->OwnerNode, itemNeeded, true, false);
+                setNodeNeededMark((AtkResNode*)itemNodeComponent->OwnerNode, itemNeeded, true, true);
             }
         }
 
-        protected override unsafe nint initializeCustomNode(nint parentNodePtr)
+        protected override unsafe NodeBase? initializeCustomNode(AtkResNode* parentNodePtr, AtkUnitBase* addon)
         {
-            AtkNineGridNode* customHighlightNode = null;
+            NineGridNode? customNode = null;
             try
             {
                 var parentNode = (AtkComponentNode*)parentNodePtr;
@@ -424,29 +426,41 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                     .SearchNodeById(hoverNodeId)
                     ->GetAsAtkNineGridNode();
 
-                customHighlightNode = UiHelper.CloneNineGridNode(AddonCustomNodeId, hoverNode);
-                customHighlightNode->SetAlpha(255);
-                customHighlightNode->DrawFlags |= 0x01; // force a redraw ("dirty flag")
-                UiHelper.LinkNodeAfterTargetNode((AtkResNode*)customHighlightNode, parentNode, (AtkResNode*)hoverNode);
+                customNode = UiHelper.CloneNineGridNode(
+                    AddonCustomNodeId,
+                    hoverNode,
+                    Plugin.Configuration.CustomNodeAddColor,
+                    Plugin.Configuration.CustomNodeMultiplyColor,
+                    Plugin.Configuration.CustomNodeAlpha
+                    ) ?? throw new Exception($"Could not clone node \"{hoverNodeId}\"");
 
-                return (nint)customHighlightNode;
+                // mark as dirty
+                customNode.InternalNode->DrawFlags |= 0x1;
+
+                // attach it to the addon
+                Services.NativeController.AttachToComponent(customNode, addon, parentNode->Component, (AtkResNode*)hoverNode, NodePosition.BeforeTarget);
+
+                return customNode;
             }
             catch (Exception ex)
             {
-                if (customHighlightNode != null) UiHelper.FreeNineGridNode(customHighlightNode);
+                customNode?.Dispose();
                 Services.Log.Error(ex, "Failed to initialize custom node");
-                return nint.Zero;
+                return null;
             }
         }
 
-        protected override unsafe void unlinkCustomNode(nint nodePtr)
+        protected override unsafe void unlinkCustomNode(nint parentNodePtr, NodeBase node)
         {
-            var node = (AtkResNode*)nodePtr;
-            var addon = (AtkUnitBase*)Services.GameGui.GetAddonByName(AddonName);
-            if (addon == null) return; // addon isn't loaded, nothing to unlink
-            if (node->ParentNode == null) return; // node isn't linked, nothing to unlink
+            var addon = Services.GameGui.GetAddonByName(AddonName);
 
-            UiHelper.UnlinkNode(node, (AtkComponentNode*)node->ParentNode);
+            if (addon == nint.Zero)
+                return;
+
+            if (parentNodePtr == nint.Zero)
+                return;
+
+            Services.NativeController.DetachFromComponent(node, (AtkUnitBase*)addon, ((AtkComponentNode*)parentNodePtr)->Component);
         }
     }
 }

--- a/BisBuddy/EventListeners/AddonEventListeners/NeedGreedEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/NeedGreedEventListener.cs
@@ -3,6 +3,7 @@ using Dalamud.Game.Addon.Lifecycle;
 using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using FFXIVClientStructs.FFXIV.Client.UI;
 using FFXIVClientStructs.FFXIV.Component.GUI;
+using KamiToolKit.Nodes;
 using System;
 using System.Collections.Generic;
 
@@ -76,14 +77,16 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             }
         }
 
-        protected override nint initializeCustomNode(nint parentNodePtr)
+        protected override unsafe NodeBase? initializeCustomNode(AtkResNode* parentNodePtr, AtkUnitBase* addon)
         {
-            throw new NotImplementedException();
+            // doesn't use custom nodes
+            return null;
         }
 
-        protected override unsafe void unlinkCustomNode(nint nodePtr)
+        protected override void unlinkCustomNode(nint parentNodePtr, NodeBase node)
         {
-            throw new NotImplementedException();
+            // doesn't use custom nodes
+            return;
         }
     }
 }

--- a/BisBuddy/EventListeners/InventoryItemEventListener.cs
+++ b/BisBuddy/EventListeners/InventoryItemEventListener.cs
@@ -1,5 +1,4 @@
 using BisBuddy.Gear;
-using BisBuddy.Items;
 using Dalamud.Game.Inventory;
 using Dalamud.Game.Inventory.InventoryEventArgTypes;
 using System;

--- a/BisBuddy/ItemAssignment/PrerequisiteAssignmentGroup.cs
+++ b/BisBuddy/ItemAssignment/PrerequisiteAssignmentGroup.cs
@@ -1,6 +1,5 @@
 using BisBuddy.Gear;
 using BisBuddy.Gear.Prerequisites;
-using BisBuddy.Items;
 using Dalamud.Game.Inventory;
 using System;
 using System.Collections.Generic;

--- a/BisBuddy/Plugin.cs
+++ b/BisBuddy/Plugin.cs
@@ -11,6 +11,7 @@ using Dalamud.Game.Command;
 using Dalamud.Interface.Windowing;
 using Dalamud.Plugin;
 using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using KamiToolKit;
 using System;
 using System.Collections.Generic;
 
@@ -88,6 +89,7 @@ public sealed partial class Plugin : IDalamudPlugin
             .RegisterSource(ImportSourceType.Etro, new EtroSource(ItemData, Services.HttpClient))
             .RegisterSource(ImportSourceType.Teamcraft, new TeamcraftPlaintextSource(ItemData))
             .RegisterSource(ImportSourceType.Json, new JsonSource());
+        Services.NativeController = new NativeController(pluginInterface);
 
         Configuration = Configuration.LoadConfig(ItemData);
 
@@ -188,6 +190,9 @@ public sealed partial class Plugin : IDalamudPlugin
 
         // dispose of http client
         Services.HttpClient.Dispose();
+
+        // dispose of native UI controller
+        Services.NativeController.Dispose();
     }
 
     private void OnCommand(string command, string args)

--- a/BisBuddy/Services.cs
+++ b/BisBuddy/Services.cs
@@ -2,6 +2,7 @@ using BisBuddy.Import;
 using Dalamud.IoC;
 using Dalamud.Plugin;
 using Dalamud.Plugin.Services;
+using KamiToolKit;
 using System.Net.Http;
 
 namespace BisBuddy
@@ -21,5 +22,6 @@ namespace BisBuddy
         [PluginService] public static IClientState ClientState { get; set; }
         public static ImportGearsetService ImportGearsetService { get; set; }
         public static HttpClient HttpClient { get; set; }
+        public static NativeController NativeController { get; set; }
     }
 }

--- a/BisBuddy/packages.lock.json
+++ b/BisBuddy/packages.lock.json
@@ -69,6 +69,9 @@
         "type": "Transitive",
         "resolved": "1.3.9",
         "contentHash": "ej6VghLaUn5/GK6jGFvd5aHn3Wue+Yp2tpmyI507PBRb/lFA6WAPS+3yKGr5wtFzh0zaE53CnCxhjc0ZW8xu3g=="
+      },
+      "kamitoolkit": {
+        "type": "Project"
       }
     }
   }


### PR DESCRIPTION
In an attempt to solve crashing, rewrite all native atk handling using KamiToolKit.

In addition, also adds small fixes, such as fixing materia window always updating no matter if there is a change made to the window, and marketboard results being highlighted such that only the first X entries with sum(X) >= quantity_needed. This should be a decent proxy for "best" purchases, but due to some lower cost-per-unit having quantities >> quantity_needed, there would need to be a full solver for this to be truly optimal