### PR TITLE
Rescan prerequisites

### DIFF
--- a/BisBuddy/Converters/GearpieceConverter.cs
+++ b/BisBuddy/Converters/GearpieceConverter.cs
@@ -21,6 +21,7 @@ namespace BisBuddy.Converters
             PrerequisiteNode? prerequisiteTree = null;
             List<Materia>? itemMateria = null;
             bool? isCollected = null;
+            bool? isManuallyCollected = null;
 
             while (reader.Read())
             {
@@ -38,11 +39,14 @@ namespace BisBuddy.Converters
                     case nameof(Gearpiece.PrerequisiteTree):
                         prerequisiteTree = JsonSerializer.Deserialize<PrerequisiteNode>(ref reader, options);
                         break;
+                    case nameof(Gearpiece.ItemMateria):
+                        itemMateria = JsonSerializer.Deserialize<List<Materia>>(ref reader, options);
+                        break;
                     case nameof(Gearpiece.IsCollected):
                         isCollected = reader.GetBoolean();
                         break;
-                    case nameof(Gearpiece.ItemMateria):
-                        itemMateria = JsonSerializer.Deserialize<List<Materia>>(ref reader, options);
+                    case nameof(Gearpiece.IsManuallyCollected):
+                        isManuallyCollected = reader.GetBoolean();
                         break;
                     default:
                         reader.Skip();
@@ -50,11 +54,15 @@ namespace BisBuddy.Converters
                 }
             }
 
+            if (itemId == null)
+                throw new JsonException("No itemId found for Gearpiece");
+
             return itemData.BuildGearpiece(
-                itemId ?? throw new JsonException("No itemId found for Gearpiece"),
+                itemId!.Value,
                 prerequisiteTree,
                 itemMateria ?? throw new JsonException("No itemMateria found for Gearpiece"),
-                isCollected ?? throw new JsonException("No isCollected found for Gearpiece")
+                isCollected ?? throw new JsonException("No isCollected found for Gearpiece"),
+                isManuallyCollected ?? false
                 );
         }
 
@@ -64,6 +72,7 @@ namespace BisBuddy.Converters
 
             writer.WriteNumber(nameof(Gearpiece.ItemId), value.ItemId);
             writer.WriteBoolean(nameof(Gearpiece.IsCollected), value.IsCollected);
+            writer.WriteBoolean(nameof(Gearpiece.IsManuallyCollected), value.IsManuallyCollected);
             writer.WriteNumber(nameof(Gearpiece.GearpieceType), (int)value.GearpieceType);
 
             writer.WritePropertyName(nameof(Gearpiece.ItemMateria));

--- a/BisBuddy/Converters/GearpieceConverter.cs
+++ b/BisBuddy/Converters/GearpieceConverter.cs
@@ -57,6 +57,14 @@ namespace BisBuddy.Converters
             if (itemId == null)
                 throw new JsonException("No itemId found for Gearpiece");
 
+            // try to extend this tree with new options
+            prerequisiteTree = itemData.ExtendItemPrerequisites(
+                itemId!.Value,
+                prerequisiteTree,
+                isCollected ?? false,
+                isManuallyCollected ?? false
+                );
+
             return itemData.BuildGearpiece(
                 itemId!.Value,
                 prerequisiteTree,

--- a/BisBuddy/Converters/PrerequisiteAtomNodeConverter.cs
+++ b/BisBuddy/Converters/PrerequisiteAtomNodeConverter.cs
@@ -60,16 +60,28 @@ namespace BisBuddy.Converters
                 }
             }
 
-            // if no children, try to extend this leaf with new nodes
-            if (prerequisiteTree?.Count == 0 && itemId != null)
-            {
-                var extendedPrerequisites = itemData.BuildGearpiecePrerequisiteTree(itemId!.Value);
-                if (extendedPrerequisites != null)
-                    prerequisiteTree.Add(extendedPrerequisites);
-            }
+            if (itemId == null)
+                throw new JsonException("No itemId found for PrerequisiteAtomNode");
+
+            // try to extend this tree with new options
+            var prerequisiteNode = prerequisiteTree != null
+                ? prerequisiteTree.Count > 0
+                ? prerequisiteTree[0]
+                : null
+                : null;
+
+            var newPrerequisiteNode = itemData.ExtendItemPrerequisites(
+                itemId!.Value,
+                prerequisiteNode,
+                isCollected ?? false,
+                isManuallyCollected ?? false
+                );
+
+            if (newPrerequisiteNode != null)
+                prerequisiteTree = [newPrerequisiteNode];
 
             return new PrerequisiteAtomNode(
-                itemId ?? throw new JsonException("No itemId found for PrerequisiteAtomNode"),
+                itemId!.Value,
                 itemName ?? throw new JsonException("No itemName found for PrerequisiteAtomNode"),
                 prerequisiteTree,
                 sourceType ?? throw new JsonException("No sourceType found for PrerequisiteAtomNode"),

--- a/BisBuddy/Gear/Gearpiece.cs
+++ b/BisBuddy/Gear/Gearpiece.cs
@@ -14,7 +14,8 @@ namespace BisBuddy.Gear
             GearpieceType gearpieceType,
             PrerequisiteNode? prerequisiteTree,
             List<Materia>? itemMateria,
-            bool isCollected = false
+            bool isCollected = false,
+            bool isManuallyCollected = false
             )
         {
             ItemId = itemId;
@@ -23,13 +24,14 @@ namespace BisBuddy.Gear
             PrerequisiteTree = prerequisiteTree;
             ItemMateria = itemMateria ?? [];
             IsCollected = isCollected;
+            IsManuallyCollected = isManuallyCollected;
         }
         public uint ItemId { get; set; }
         public string ItemName { get; set; }
         public GearpieceType GearpieceType { get; set; }
         public PrerequisiteNode? PrerequisiteTree { get; set; } // relations with other items that can be used to obtain this gearpiece
         public bool IsCollected { get; private set; }
-        public bool IsManuallyCollected { get; set; } = false; // If this item was manually marked as collected
+        public bool IsManuallyCollected { get; private set; } // If this item was manually marked as collected
         public bool IsObtainable => PrerequisiteTree?.IsObtainable ?? false; // If no prerequisites known, assume not obtainable
         public List<Materia> ItemMateria { get; init; }
         private List<(Materia Materia, int Count)>? itemMateriaGrouped = null;

--- a/BisBuddy/Items/ItemData.cs
+++ b/BisBuddy/Items/ItemData.cs
@@ -419,7 +419,8 @@ namespace BisBuddy.Items
             uint itemId,
             PrerequisiteNode? prerequisiteTree,
             List<GearMateria> itemMateria,
-            bool isCollected = false
+            bool isCollected = false,
+            bool isManuallyCollected = false
             )
         {
             return new Gearpiece(
@@ -428,7 +429,8 @@ namespace BisBuddy.Items
                 GetItemGearpieceType(itemId),
                 prerequisiteTree,
                 itemMateria,
-                isCollected
+                isCollected,
+                isManuallyCollected
                 );
         }
 

--- a/BisBuddy/Plugin.cs
+++ b/BisBuddy/Plugin.cs
@@ -306,6 +306,6 @@ public sealed partial class Plugin : IDalamudPlugin
 
     public string ExportGearsetToJsonStr(Gearset gearset)
     {
-        return JsonSerializer.Serialize(this, jsonOptions);
+        return JsonSerializer.Serialize(gearset, jsonOptions);
     }
 }


### PR DESCRIPTION
- To fully support prerequisite extension, additional situations were added (before it was just leaves)
- When OLD is a non-OR node and NEW is, add the OR layer
- When OLD and NEW is an OR node, compare them and add whichever branches don't exist in old.

- Bugfixes:
-  add manually collected status of gearpieces to custom serialization
- fix exporting as a json string