### PR TITLE
Fix crashing again

### DIFF
--- a/BisBuddy/EventListeners/AddonEventListeners/ItemDetailEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ItemDetailEventListener.cs
@@ -53,17 +53,21 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         // list of gearset names that need the currently hovered item
         private List<(Gearset gearset, int countNeeded)> neededGearsets = [];
 
+        protected override float CustomNodeMaxY => float.MaxValue;
+
         protected override void registerAddonListeners()
         {
+            Plugin.OnGearsetsUpdate += handleManualUpdate;
             Services.GameGui.HoveredItemChanged += handleHoveredItemChanged;
         }
 
         protected override void unregisterAddonListeners()
         {
+            Plugin.OnGearsetsUpdate -= handleManualUpdate;
             Services.GameGui.HoveredItemChanged -= handleHoveredItemChanged;
             neededGearsets = [];
         }
-        public override void handleManualUpdate()
+        private void handleManualUpdate()
         {
             // manually trigger refresh
             handleHoveredItemChanged(null, Services.GameGui.HoveredItem);

--- a/BisBuddy/EventListeners/AddonEventListeners/ItemSearchEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ItemSearchEventListener.cs
@@ -190,7 +190,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 customNode.InternalNode->DrawFlags |= 0x1;
 
                 // attach it to the addon
-                Services.NativeController.AttachToComponent(customNode, addon, parentNode->Component, (AtkResNode*)hoverNode, NodePosition.BeforeTarget);
+                Services.NativeController.AttachToAddon(customNode, addon, addon->RootNode, NodePosition.AsLastChild);
 
                 return customNode;
             }
@@ -212,7 +212,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             if (parentNodePtr == nint.Zero)
                 return;
 
-            Services.NativeController.DetachFromComponent(node, (AtkUnitBase*)addon, ((AtkComponentNode*)parentNodePtr)->Component);
+            Services.NativeController.DetachFromAddon(node, (AtkUnitBase*)addon);
         }
     }
 }

--- a/BisBuddy/EventListeners/AddonEventListeners/ItemSearchEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ItemSearchEventListener.cs
@@ -9,7 +9,6 @@ using KamiToolKit.Classes;
 using KamiToolKit.Nodes;
 using System;
 using System.Collections.Generic;
-using System.Linq;
 
 namespace BisBuddy.EventListeners.AddonEventListeners
 {
@@ -20,64 +19,31 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         public override string AddonName => "ItemSearch";
 
         // ADDON NODE IDS
-        // id of the text node for the list item name
-        public static readonly uint AddonItemNameTextNodeId = 13;
         // id of the hover highlight node
         public static readonly uint AddonHoverHighlightNodeId = 15;
-        // id of the list of items being displayed (and the scrollbar)
-        public static readonly uint AddonItemListNodeId = 139;
-        // id of the scrollbar in the list of items
-        public static readonly uint AddonItemScrollbarNodeId = 4;
-        // id of the scroll button on the bar
-        public static readonly uint AddonItemScrollButtonNodeId = 2;
 
         // what items are needed from the marketboard listings
         private readonly HashSet<int> neededItemIndexes = [];
-        // the item list from the last refresh
-        private List<string> previousItemNames = [];
-        // the previous Y value of the scrollbar
-        private float previousScrollbarY = -1.0f;
+
+        protected override float CustomNodeMaxY => 500f;
 
         protected override void registerAddonListeners()
         {
-            Services.AddonLifecycle.RegisterListener(AddonEvent.PostRequestedUpdate, AddonName, handlePostRequestedUpdate);
-            Services.AddonLifecycle.RegisterListener(AddonEvent.PostRefresh, AddonName, handlePostRefresh);
             Services.AddonLifecycle.RegisterListener(AddonEvent.PreDraw, AddonName, handlePreDraw);
         }
         protected override void unregisterAddonListeners()
         {
-            Services.AddonLifecycle.UnregisterListener(handlePostRequestedUpdate);
-            Services.AddonLifecycle.UnregisterListener(handlePostRefresh);
             Services.AddonLifecycle.UnregisterListener(handlePreDraw);
         }
 
-        public override void handleManualUpdate()
-        {
-            updateNeededItems();
-        }
-
-        private unsafe void handlePostRequestedUpdate(AddonEvent type, AddonArgs args)
-        {
-            updateNeededItems();
-        }
-
-        private unsafe void handlePostRefresh(AddonEvent type, AddonArgs args)
-        {
-            updateNeededItems();
-        }
-
-        private void handlePreDraw(AddonEvent type, AddonArgs args)
-        {
-            handleUpdate();
-        }
-
-        private unsafe void handleUpdate()
+        private unsafe void handlePreDraw(AddonEvent type, AddonArgs args)
         {
             try
             {
+                updateNeededItems();
                 if (neededItemIndexes.Count == 0)
                 { // no items needed from list, return
-                    unmarkAllNodes();
+                    unmarkNodes();
                     return;
                 };
                 var addon = (AddonItemSearch*)Services.GameGui.GetAddonByName(AddonName);
@@ -85,30 +51,6 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 if (addon->ResultsList == null || addon->ResultsList->ListLength == 0) return; // no items in search
 
                 var itemList = addon->ResultsList;
-
-                // list length doesn't match up, something must have changed
-                if (itemList->ListLength != previousItemNames.Count)
-                {
-                    previousItemNames = Enumerable.Repeat(string.Empty, itemList->ListLength).ToList();
-                }
-
-                var addonNode = new BaseNode(&addon->AtkUnitBase);
-                var scrollbarNode = addonNode.GetNestedNode<AtkResNode>([
-                    AddonItemListNodeId,
-                    AddonItemScrollbarNodeId,
-                    AddonItemScrollButtonNodeId
-                    ]);
-
-                if (scrollbarNode == null)
-                {
-                    Services.Log.Warning($"{GetType().Name}: Failed to find scrollbar node");
-                }
-                else
-                {
-                    // scrollbar in same position, nodes haven't changed
-                    if (scrollbarNode->Y == previousScrollbarY) return;
-                    previousScrollbarY = scrollbarNode->Y;
-                }
 
                 var firstListItemIndex = -1;
                 for (var i = 0; i < itemList->ListLength; i++)
@@ -125,7 +67,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             }
             catch (Exception ex)
             {
-                Services.Log.Error(ex, $"{GetType().Name}: Failed to update PostDraw");
+                Services.Log.Error(ex, $"{GetType().Name}: Failed to update PreDraw");
             }
         }
 
@@ -144,9 +86,8 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                     var hqItemId = Plugin.ItemData.ConvertItemIdToHq(nqItemId);
 
                     var nqOrHqNeeded = (
-                        Gearset.GetGearsetsNeedingItemById(nqItemId, Plugin.Gearsets).Count > 0 // either the NQ is needed
-                        || (hqItemId != nqItemId // or there is a HQ variant and it is needed
-                            && Gearset.GetGearsetsNeedingItemById(hqItemId, Plugin.Gearsets).Count > 0)
+                        Gearset.GearsetsNeedItemId(nqItemId, Plugin.Gearsets) // either the NQ is needed
+                        || Gearset.GearsetsNeedItemId(hqItemId, Plugin.Gearsets) // or HQ is needed
                         );
                     if (nqOrHqNeeded) // needed at some level
                     {
@@ -154,10 +95,6 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                         neededItemIndexes.Add(i);
                     }
                 }
-
-                // ensure this update refreshes the draws by resetting caches
-                previousItemNames.Clear();
-                previousScrollbarY = -1.0f;
             }
             catch (Exception ex)
             {

--- a/BisBuddy/EventListeners/AddonEventListeners/ItemSearchResultEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ItemSearchResultEventListener.cs
@@ -236,7 +236,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 customNode.InternalNode->DrawFlags |= 0x1;
 
                 // attach it to the addon
-                Services.NativeController.AttachToComponent(customNode, addon, parentNode->Component, (AtkResNode*)hoverNode, NodePosition.BeforeTarget);
+                Services.NativeController.AttachToAddon(customNode, addon, addon->RootNode, NodePosition.AsLastChild);
 
                 return customNode;
             }
@@ -258,7 +258,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             if (parentNodePtr == nint.Zero)
                 return;
 
-            Services.NativeController.DetachFromComponent(node, (AtkUnitBase*)addon, ((AtkComponentNode*)parentNodePtr)->Component);
+            Services.NativeController.DetachFromAddon(node, (AtkUnitBase*)addon);
         }
     }
 }

--- a/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
@@ -438,7 +438,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 customNode.InternalNode->DrawFlags |= 0x1;
 
                 // attach it to the addon
-                Services.NativeController.AttachToComponent(customNode, addon, parentNode->Component, (AtkResNode*)hoverNode, NodePosition.BeforeTarget);
+                Services.NativeController.AttachToAddon(customNode, addon, addon->RootNode, NodePosition.AsLastChild);
 
                 return customNode;
             }
@@ -460,7 +460,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             if (parentNodePtr == nint.Zero)
                 return;
 
-            Services.NativeController.DetachFromComponent(node, (AtkUnitBase*)addon, ((AtkComponentNode*)parentNodePtr)->Component);
+            Services.NativeController.DetachFromAddon(node, (AtkUnitBase*)addon);
         }
     }
 }

--- a/BisBuddy/EventListeners/AddonEventListeners/NeedGreedEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/NeedGreedEventListener.cs
@@ -20,28 +20,21 @@ namespace BisBuddy.EventListeners.AddonEventListeners
 
         public override string AddonName => "NeedGreed";
 
+        protected override float CustomNodeMaxY => float.MaxValue;
+
         protected override void registerAddonListeners()
         {
-            Services.AddonLifecycle.RegisterListener(AddonEvent.PostRequestedUpdate, AddonName, handlePostRefresh);
+            Services.AddonLifecycle.RegisterListener(AddonEvent.PreDraw, AddonName, handlePreDraw);
         }
 
         protected override void unregisterAddonListeners()
         {
-            Services.AddonLifecycle.UnregisterListener(handlePostRefresh);
+            Services.AddonLifecycle.UnregisterListener(handlePreDraw);
         }
 
-        public override unsafe void handleManualUpdate()
+        private unsafe void handlePreDraw(AddonEvent type, AddonArgs args)
         {
-            handleUpdate((AddonNeedGreed*)Services.GameGui.GetAddonByName(AddonName));
-        }
-
-        private unsafe void handlePostRefresh(AddonEvent type, AddonArgs args)
-        {
-            handleUpdate((AddonNeedGreed*)args.Addon);
-        }
-
-        private unsafe void handleUpdate(AddonNeedGreed* addon)
-        {
+            var addon = (AddonNeedGreed*)args.Addon;
             try
             {
                 if (addon == null || !addon->IsVisible) return;
@@ -50,10 +43,8 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 for (var itemIdx = 0; itemIdx < addon->NumItems; itemIdx++)
                 {
                     var lootItem = addon->Items[itemIdx];
-                    if (Gearset.GetGearsetsNeedingItemById(lootItem.ItemId, Plugin.Gearsets).Count > 0)
-                    {
+                    if (Gearset.GearsetsNeedItemId(lootItem.ItemId, Plugin.Gearsets))
                         itemIndexesToHighlight.Add(itemIdx);
-                    }
                 }
 
                 highlightItems(itemIndexesToHighlight, addon);

--- a/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeCurrencyEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeCurrencyEventListener.cs
@@ -5,6 +5,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
     {
         // the type of shop this is (what do items in this shop cost?)
         public override string AddonName => "ShopExchangeCurrency";
+        protected override float CustomNodeMaxY => 384;
 
         // ADDON ATKVALUE INDEXES
         protected override int AtkValueItemCountIndex => 4;
@@ -20,5 +21,6 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
         protected override uint AddonScrollbarNodeId => 6;
         protected override uint AddonScrollbarButtonNodeId => 2;
         protected override uint AddonShieldInfoResNodeId => 3;
+        protected override uint NoItemsTextNodeId => 20;
     }
 }

--- a/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeEventListener.cs
@@ -298,7 +298,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
                 customNode.InternalNode->DrawFlags |= 0x1;
 
                 // attach it to the addon
-                Services.NativeController.AttachToComponent(customNode, addon, ((AtkComponentNode*)parentNodePtr)->Component, (AtkResNode*)hoverNode, NodePosition.BeforeTarget);
+                Services.NativeController.AttachToAddon(customNode, addon, addon->RootNode, NodePosition.AsLastChild);
 
                 return customNode;
             }
@@ -320,7 +320,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
             if (parentNodePtr == nint.Zero)
                 return;
 
-            Services.NativeController.DetachFromComponent(node, (AtkUnitBase*)addon, ((AtkComponentNode*)parentNodePtr)->Component);
+            Services.NativeController.DetachFromAddon(node, (AtkUnitBase*)addon);
         }
     }
 }

--- a/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeEventListener.cs
@@ -30,6 +30,8 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
         protected abstract uint AddonScrollbarButtonNodeId { get; }
         // node on shield item entries that contains info, and is offset in by L bar
         protected abstract uint AddonShieldInfoResNodeId { get; }
+        // text node that displays when there are no items to be listed
+        protected abstract uint NoItemsTextNodeId { get; }
         // if an indented is in the item list, what is item index?
         // should be constant throughout all shops now
         protected int AddonShieldIndex = 1;
@@ -46,105 +48,39 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
 
         private readonly HashSet<int> neededShopItemIndexes = [];
         private bool shieldInAtkValues = false;
-        // the previous Y value of the scrollbar
-        private float previousScrollbarY = -1.0f;
 
         protected override void registerAddonListeners()
         {
-            Services.AddonLifecycle.RegisterListener(AddonEvent.PostSetup, AddonName, handlePostSetup);
-            Services.AddonLifecycle.RegisterListener(AddonEvent.PostRefresh, AddonName, handlePostRefresh);
-            Services.AddonLifecycle.RegisterListener(AddonEvent.PostUpdate, AddonName, handlePostUpdate);
+            Services.AddonLifecycle.RegisterListener(AddonEvent.PreDraw, AddonName, handlePreDraw);
         }
 
         protected override void unregisterAddonListeners()
         {
-            Services.AddonLifecycle.UnregisterListener(handlePostSetup);
-            Services.AddonLifecycle.UnregisterListener(handlePostRefresh);
-            Services.AddonLifecycle.UnregisterListener(handlePostUpdate);
+            Services.AddonLifecycle.UnregisterListener(handlePreDraw);
         }
 
-        public override unsafe void handleManualUpdate()
+        private unsafe void handlePreDraw(AddonEvent type, AddonArgs args)
         {
             try
             {
-                // get the addon
-                var addon = (AtkUnitBase*)Services.GameGui.GetAddonByName(AddonName);
-                if (addon == null || !addon->IsVisible) return;
+                var addon = (AtkUnitBase*)((AddonDrawArgs)args).Addon;
 
-                var atkValuesSpan = new Span<AtkValue>(addon->AtkValues, addon->AtkValuesCount);
+                var shopExchangeNode = new BaseNode(addon);
 
-                // update list of items needed from shop
-                updateNeededShopItemIndexes(atkValuesSpan);
+                var noEntriesTextNode = shopExchangeNode.GetNode<AtkTextNode>(NoItemsTextNodeId);
 
-                // reset cache of previous item names to force redraw highlight
-                previousScrollbarY = -1.0f;
-            }
-            catch (Exception e)
-            {
-                Services.Log.Error(e, $"Failed to handle GearsetsUpdate for {AddonName}");
-            }
-        }
-
-        private unsafe void handlePostSetup(AddonEvent type, AddonArgs args)
-        {
-            try
-            {
-                // skip if type is not correct
-                if (type != AddonEvent.PostSetup) return;
-                var setupArgs = (AddonSetupArgs)args;
-                previousScrollbarY = -1.0f;
-                updateNeededShopItemIndexes(setupArgs.AtkValueSpan);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, $"Error in handlePostSetup");
-            }
-        }
-
-        private unsafe void handlePostRefresh(AddonEvent type, AddonArgs args)
-        {
-            try
-            {
-                // skip if type is not correct
-                if (type != AddonEvent.PostRefresh) return;
-                var receiveEventArgs = (AddonRefreshArgs)args;
-                previousScrollbarY = -1.0f;
-                updateNeededShopItemIndexes(receiveEventArgs.AtkValueSpan);
-            }
-            catch (Exception ex)
-            {
-                Log.Error(ex, "Error in handlePostRefresh");
-            }
-        }
-
-        private unsafe void handlePostUpdate(AddonEvent type, AddonArgs args)
-        {
-            try
-            {
+                updateNeededShopItemIndexes(addon->AtkValuesSpan);
                 // skip if no items are needed in this shop
-                if (neededShopItemIndexes.Count == 0)
+                if (neededShopItemIndexes.Count == 0 || (noEntriesTextNode != null && noEntriesTextNode->IsVisible()))
                 {
                     // remove highlight on all items if there are no items needed
-                    unmarkAllNodes();
+                    unmarkNodes();
                     return;
                 };
 
-                var addon = (AtkUnitBase*)Services.GameGui.GetAddonByName(AddonName);
                 if (addon == null || !addon->IsVisible) return;
 
-                var shopExchangeItemNode = new BaseNode(addon);
-
-                var scrollbarNode = shopExchangeItemNode.GetNestedNode<AtkResNode>([
-                    AddonShopItemListNodeId,
-                    AddonScrollbarNodeId,
-                    AddonScrollbarButtonNodeId
-                    ]);
-
-                // check if scroll location is the same, quit out if so
-                if (scrollbarNode->Y == previousScrollbarY) return;
-                previousScrollbarY = scrollbarNode->Y;
-
-                var itemTreeListComponent = (AtkComponentTreeList*)shopExchangeItemNode
+                var itemTreeListComponent = (AtkComponentTreeList*)shopExchangeNode
                     .GetComponentNode(AddonShopItemListNodeId)
                     .GetPointer()->Component;
 
@@ -194,10 +130,8 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
                 shieldInAtkValues = true;
 
                 // add if needed
-                if (Gearset.GetGearsetsNeedingItemById(endOfItemIdList.UInt, Plugin.Gearsets).Count > 0)
-                {
+                if (Gearset.GearsetsNeedItemId(endOfItemIdList.UInt, Plugin.Gearsets))
                     neededShopItemIndexes.Add(AddonShieldIndex);
-                }
             }
 
             // handle other items
@@ -213,14 +147,12 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
                     ? 1  // shield visible and idx after where shield goes
                     : 0; // either shield not visible or before where shield goes
 
-                if (Gearset.GetGearsetsNeedingItemById(itemId, Plugin.Gearsets).Count > 0)
+                if (Gearset.GearsetsNeedItemId(itemId, Plugin.Gearsets))
                 {
                     var filteredIndex = getFilteredIndex(i, atkValues);
                     if (filteredIndex >= 0) neededShopItemIndexes.Add(filteredIndex + shieldOffset);
                 }
             }
-
-            Services.Log.Debug($"Found {neededShopItemIndexes.Count} item(s) needed in shop");
         }
 
         private unsafe int getFilteredIndex(int index, Span<AtkValue> atkValues)

--- a/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeItemEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeItemEventListener.cs
@@ -5,6 +5,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
     {
         // the type of shop this is (what do items in this shop cost?)
         public override string AddonName => "ShopExchangeItem";
+        protected override float CustomNodeMaxY => 312;
 
         // ADDON ATKVALUE INDEXES
         protected override int AtkValueItemCountIndex => 3;
@@ -20,5 +21,6 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
         protected override uint AddonScrollbarNodeId => 6;
         protected override uint AddonScrollbarButtonNodeId => 2;
         protected override uint AddonShieldInfoResNodeId => 3;
+        protected override uint NoItemsTextNodeId => 18;
     }
 }

--- a/BisBuddy/EventListeners/InventoryItemEventListener.cs
+++ b/BisBuddy/EventListeners/InventoryItemEventListener.cs
@@ -48,7 +48,7 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (Gearset.GetGearsetsNeedingItemById(addedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true).Count == 0)
+                if (Gearset.GearsetsNeedItemId(addedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
                     return;
 
                 // added to type we track, update gearsets
@@ -71,7 +71,7 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (Gearset.GetGearsetsNeedingItemById(removedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true).Count == 0)
+                if (Gearset.GearsetsNeedItemId(removedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
                     return;
 
                 // removed from type we track, update gearsets
@@ -94,7 +94,7 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (Gearset.GetGearsetsNeedingItemById(changedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true).Count == 0)
+                if (Gearset.GearsetsNeedItemId(changedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
                     return;
 
                 // changed in a type we track, update gearsets
@@ -117,7 +117,7 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (Gearset.GetGearsetsNeedingItemById(movedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true).Count == 0)
+                if (Gearset.GearsetsNeedItemId(movedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
                     return;
 
                 // moved untracked -> tracked or tracked -> untracked, update gearsets

--- a/BisBuddy/Gear/Gearpiece.cs
+++ b/BisBuddy/Gear/Gearpiece.cs
@@ -82,9 +82,30 @@ namespace BisBuddy.Gear
                 PrerequisiteTree.SetCollected(false, manualToggle);
         }
 
+        public bool NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs)
+        {
+            // not a real item, can't be needed
+            if (candidateItemId == 0)
+                return false;
+
+            // If this item is marked as collected, only way item is needed is if it is materia
+            if (IsCollected && ignoreCollected)
+                return ItemMateria.Any(materia => (!materia.IsMelded || !ignoreCollected) && candidateItemId == materia.ItemId);
+
+            // is this the gearpiece itself
+            if (candidateItemId == ItemId)
+                return true;
+
+            // only can be needed as materia or a prerequisite
+            return (
+                ItemMateria.Any(materia => (!materia.IsMelded || !ignoreCollected) && candidateItemId == materia.ItemId)
+                || (PrerequisiteTree?.ItemNeededCount(candidateItemId, !includeCollectedPrereqs && ignoreCollected) ?? 0) > 0
+                );
+        }
+
 
         // return the number of this item needed for this gearpiece
-        public int NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs)
+        public int NeedsItemIdCount(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs)
         {
             // not a real item, can't be needed
             if (candidateItemId == 0) return 0;

--- a/BisBuddy/Gear/Gearset.Util.cs
+++ b/BisBuddy/Gear/Gearset.Util.cs
@@ -30,6 +30,24 @@ namespace BisBuddy.Gear
             return satisfiedGearsets;
         }
 
+        /// <summary>
+        /// Whether a list of gearsets need a specific item id in some way (as the gearpiece, as a gearpiece prerequisite, or as a materia).
+        /// Ignores gearsets marked as inactive in the list.
+        /// </summary>
+        /// <param name="itemId">The item id to check</param>
+        /// <param name="gearsets">The list of gearsets to check if the item is needed in</param>
+        /// <param name="ignoreCollected">Whether to ignore gearpieces that are marked as collected when checking needed status</param>
+        /// <param name="includeCollectedPrereqs">Whether to include prerequisites marked as collected. True for 'internal' inventory sources.
+        /// False for external sources outside of player inventory</param>
+        /// <returns>If the item is needed in any way by any of the gearsets listed</returns>
+        public static bool GearsetsNeedItemId(
+            uint itemId,
+            List<Gearset> gearsets,
+            bool ignoreCollected = true,
+            bool includeCollectedPrereqs = false
+            ) =>
+            gearsets.Any(gearset => gearset.NeedsItemId(itemId, ignoreCollected, includeCollectedPrereqs));
+
         public static List<MeldPlan> GetNeededItemMeldPlans(uint itemId, List<Gearset> gearsets)
         {
             var neededMeldPlans = new List<MeldPlan>();

--- a/BisBuddy/Gear/Gearset.cs
+++ b/BisBuddy/Gear/Gearset.cs
@@ -1,6 +1,7 @@
 using BisBuddy.Import;
 using System;
 using System.Collections.Generic;
+using System.Linq;
 
 namespace BisBuddy.Gear
 {
@@ -52,7 +53,7 @@ namespace BisBuddy.Gear
             List<(Gearpiece gearpiece, int countNeeded)> satisfiedGearpieces = [];
             foreach (var gearpiece in Gearpieces)
             {
-                var countNeeded = gearpiece.NeedsItemId(candidateItemId, ignoreCollected, includeCollectedPrereqs);
+                var countNeeded = gearpiece.NeedsItemIdCount(candidateItemId, ignoreCollected, includeCollectedPrereqs);
                 if (countNeeded > 0)
                 {
                     satisfiedGearpieces.Add((gearpiece, countNeeded));
@@ -60,5 +61,8 @@ namespace BisBuddy.Gear
             }
             return satisfiedGearpieces;
         }
+
+        public bool NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs) =>
+            IsActive && Gearpieces.Any(gearpiece => gearpiece.NeedsItemId(candidateItemId, ignoreCollected, includeCollectedPrereqs));
     }
 }

--- a/BisBuddy/Items/ItemData.Generate.cs
+++ b/BisBuddy/Items/ItemData.Generate.cs
@@ -122,8 +122,8 @@ namespace BisBuddy.Items
                 // group items by EquipSlotCategory/ClassJobCategory pair, since cannot contain multiple from each grouping from 1 coffer
                 var groupedItemsAtIlvl = itemsAtIlvl
                     .GroupBy(
-                        item => new 
-                        { 
+                        item => new
+                        {
                             equipSlotCategory = item.EquipSlotCategory.RowId,
                             classJobCategory = item.ClassJobCategory.RowId,
                         });

--- a/BisBuddy/Plugin.cs
+++ b/BisBuddy/Plugin.cs
@@ -264,22 +264,8 @@ public sealed partial class Plugin : IDalamudPlugin
 
     public void UpdateMeldPlanSelectorWindow(List<MeldPlan> meldPlans)
     {
-
-        if (meldPlans.Count == 0)
-        {
-            if (MeldPlanSelectorWindow.IsOpen)
-            {
-                MeldPlanSelectorWindow.Toggle();
-            }
-        }
-        else
-        {
-            MeldPlanSelectorWindow.MeldPlans = meldPlans;
-            if (!MeldPlanSelectorWindow.IsOpen)
-            {
-                MeldPlanSelectorWindow.Toggle();
-            }
-        }
+        MeldPlanSelectorWindow.MeldPlans = meldPlans;
+        MeldPlanSelectorWindow.IsOpen = meldPlans.Count > 0;
     }
 
     public static unsafe void SearchItemById(uint itemId)

--- a/BisBuddy/Util/UiHelper.cs
+++ b/BisBuddy/Util/UiHelper.cs
@@ -123,6 +123,8 @@ public static unsafe partial class UiHelper
                 Scale = new(clonedNode->ScaleX, clonedNode->ScaleY),
                 X = clonedNode->X,
                 Y = clonedNode->Y,
+                ScreenX = clonedNode->ScreenX,
+                ScreenY = clonedNode->ScreenY,
                 Rotation = clonedNode->Rotation,
                 Offsets = new(clonedNode->TopOffset, clonedNode->BottomOffset, clonedNode->LeftOffset, clonedNode->RightOffset),
                 BlendMode = clonedNode->BlendMode,


### PR DESCRIPTION
Rewrite/simplify all addon logic in attempt to fix crashing

- Custom nodes are now attached to the addon root node. No longer attaches to component
- Addon highlighting logic now runs less stateful, listening to predraw for most of its logic