### PR TITLE
Melding prerequisites

### DIFF
--- a/BisBuddy/Configuration.cs
+++ b/BisBuddy/Configuration.cs
@@ -24,6 +24,8 @@ public class Configuration : IPluginConfiguration
     public bool HighlightShops { get; set; } = true;
     public bool HighlightMateriaMeld { get; set; } = true;
     public bool HighlightNextMateria { get; set; } = false;
+    public bool HighlightCollectedItemMateria { get; set; } = false;
+    public bool HighlightPrerequisiteMateria { get; set; } = true;
     public bool HighlightInventories { get; set; } = true;
     public bool HighlightMarketboard { get; set; } = true;
     public bool AnnotateTooltips { get; set; } = true;

--- a/BisBuddy/Converters/PrerequisiteAtomNodeConverter.cs
+++ b/BisBuddy/Converters/PrerequisiteAtomNodeConverter.cs
@@ -24,6 +24,7 @@ namespace BisBuddy.Converters
             PrerequisiteNodeSourceType? sourceType = null;
             bool? isCollected = null;
             bool? isManuallyCollected = null;
+            bool isMeldable = false;
 
             while (reader.Read())
             {
@@ -37,7 +38,8 @@ namespace BisBuddy.Converters
                 {
                     case nameof(PrerequisiteNode.ItemId):
                         itemId = reader.GetUInt32();
-                        itemName = itemData.GetItemNameById(reader.GetUInt32());
+                        itemName = itemData.GetItemNameById(itemId!.Value);
+                        isMeldable = itemData.ItemIsMeldable(itemId!.Value);
                         break;
                     case nameof(PrerequisiteNode.NodeId):
                         nodeId = reader.GetString();
@@ -87,7 +89,8 @@ namespace BisBuddy.Converters
                 sourceType ?? throw new JsonException("No sourceType found for PrerequisiteAtomNode"),
                 isCollected ?? throw new JsonException("No isCollected found for PrerequisiteAtomNode"),
                 isManuallyCollected ?? throw new JsonException("No isManuallyCollected found for PrerequisiteAtomNode"),
-                nodeId ?? throw new JsonException("No nodeId found for PrerequisiteAtomNode")
+                nodeId ?? throw new JsonException("No nodeId found for PrerequisiteAtomNode"),
+                isMeldable
                 );
         }
 

--- a/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
@@ -90,10 +90,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
 
         public override unsafe void handleManualUpdate()
         {
-            unmeldedGearpieceNames = Gearset
-                .GetUnmeldedGearpieces(Plugin.Gearsets)
-                .Select(g => g.ItemName)
-                .ToHashSet();
+            unmeldedGearpieceNames = Gearset.GetUnmeldedItemNames(Plugin.Gearsets);
 
             var addon = (AtkUnitBase*)Services.GameGui.GetAddonByName(AddonName);
             if (addon == null || !addon->IsVisible) return;
@@ -103,10 +100,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
 
         public unsafe void handlePostSetup(AddonEvent type, AddonArgs args)
         {
-            unmeldedGearpieceNames = Gearset
-                .GetUnmeldedGearpieces(Plugin.Gearsets)
-                .Select(g => g.ItemName)
-                .ToHashSet();
+            unmeldedGearpieceNames = Gearset.GetUnmeldedItemNames(Plugin.Gearsets);
 
             updateState((AtkUnitBase*)args.Addon);
         }

--- a/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
@@ -49,7 +49,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         private string selectedItemName = string.Empty;
         private readonly HashSet<int> unmeldedItemIndexes = [];
         private readonly HashSet<int> neededMateriaIndexes = [];
-        private HashSet<string> unmeldedGearpieceNames = Gearset.GetUnmeldedItemNames(plugin.Gearsets);
+        private HashSet<string> unmeldedItemNames = Gearset.GetUnmeldedItemNames(plugin.Gearsets);
         private HashSet<string> neededMateriaNames = [];
 
         public List<MeldPlan> meldPlans { get; private set; } = [];
@@ -63,6 +63,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             Plugin.OnGearsetsUpdate += handleManualUpdate;
             Services.AddonLifecycle.RegisterListener(AddonEvent.PreDraw, AddonName, handlePreDraw);
             Services.AddonLifecycle.RegisterListener(AddonEvent.PreFinalize, AddonName, handlePreFinalize);
+            unmeldedItemNames = Gearset.GetUnmeldedItemNames(plugin.Gearsets);
         }
 
         protected override void unregisterAddonListeners()
@@ -75,7 +76,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
 
         private void handleManualUpdate()
         {
-            unmeldedGearpieceNames = Gearset.GetUnmeldedItemNames(Plugin.Gearsets);
+            unmeldedItemNames = Gearset.GetUnmeldedItemNames(Plugin.Gearsets);
         }
 
         private void handlePreFinalize(AddonEvent type, AddonArgs? args)
@@ -251,7 +252,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             updateRequiredIndexes(
                 addon,
                 unmeldedItemIndexes,
-                unmeldedGearpieceNames,
+                unmeldedItemNames,
                 AtkValueItemNameListStartIndex
                 );
         }

--- a/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/MateriaAttachEventListener.cs
@@ -49,7 +49,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         private string selectedItemName = string.Empty;
         private readonly HashSet<int> unmeldedItemIndexes = [];
         private readonly HashSet<int> neededMateriaIndexes = [];
-        private HashSet<string> unmeldedItemNames = Gearset.GetUnmeldedItemNames(plugin.Gearsets);
+        private HashSet<string> unmeldedItemNames = Gearset.GetUnmeldedItemNames(plugin.Gearsets, plugin.Configuration.HighlightPrerequisiteMateria);
         private HashSet<string> neededMateriaNames = [];
 
         public List<MeldPlan> meldPlans { get; private set; } = [];
@@ -63,7 +63,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
             Plugin.OnGearsetsUpdate += handleManualUpdate;
             Services.AddonLifecycle.RegisterListener(AddonEvent.PreDraw, AddonName, handlePreDraw);
             Services.AddonLifecycle.RegisterListener(AddonEvent.PreFinalize, AddonName, handlePreFinalize);
-            unmeldedItemNames = Gearset.GetUnmeldedItemNames(plugin.Gearsets);
+            unmeldedItemNames = Gearset.GetUnmeldedItemNames(Plugin.Gearsets, Plugin.Configuration.HighlightPrerequisiteMateria);
         }
 
         protected override void unregisterAddonListeners()
@@ -76,7 +76,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
 
         private void handleManualUpdate()
         {
-            unmeldedItemNames = Gearset.GetUnmeldedItemNames(Plugin.Gearsets);
+            unmeldedItemNames = Gearset.GetUnmeldedItemNames(Plugin.Gearsets, Plugin.Configuration.HighlightPrerequisiteMateria);
         }
 
         private void handlePreFinalize(AddonEvent type, AddonArgs? args)
@@ -105,7 +105,11 @@ namespace BisBuddy.EventListeners.AddonEventListeners
         private void updateMateriaMeldPlans()
         {
             if (selectedItemName != string.Empty)
-                meldPlans = Gearset.GetNeededItemMeldPlans(Plugin.ItemData.GetItemIdByName(selectedItemName), Plugin.Gearsets);
+                meldPlans = Gearset.GetNeededItemMeldPlans(
+                    Plugin.ItemData.GetItemIdByName(selectedItemName),
+                    Plugin.Gearsets,
+                    Plugin.Configuration.HighlightPrerequisiteMateria
+                    );
             else
                 meldPlans.Clear();
 

--- a/BisBuddy/Gear/Gearpiece.cs
+++ b/BisBuddy/Gear/Gearpiece.cs
@@ -82,7 +82,7 @@ namespace BisBuddy.Gear
                 PrerequisiteTree.SetCollected(false, manualToggle);
         }
 
-        public bool NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs)
+        public bool NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs, bool includeAsPrerequisite = true)
         {
             // not a real item, can't be needed
             if (candidateItemId == 0)
@@ -96,11 +96,12 @@ namespace BisBuddy.Gear
             if (candidateItemId == ItemId)
                 return true;
 
+            var neededAsMateria = ItemMateria.Any(materia => (!materia.IsMelded || !ignoreCollected) && candidateItemId == materia.ItemId);
+            var neededAsPrerequisite = includeAsPrerequisite
+                && (PrerequisiteTree?.ItemNeededCount(candidateItemId, !includeCollectedPrereqs && ignoreCollected) ?? 0) > 0;
+
             // only can be needed as materia or a prerequisite
-            return (
-                ItemMateria.Any(materia => (!materia.IsMelded || !ignoreCollected) && candidateItemId == materia.ItemId)
-                || (PrerequisiteTree?.ItemNeededCount(candidateItemId, !includeCollectedPrereqs && ignoreCollected) ?? 0) > 0
-                );
+            return neededAsMateria || neededAsPrerequisite;
         }
 
 

--- a/BisBuddy/Gear/Gearset.Util.cs
+++ b/BisBuddy/Gear/Gearset.Util.cs
@@ -48,7 +48,7 @@ namespace BisBuddy.Gear
             ) =>
             gearsets.Any(gearset => gearset.NeedsItemId(itemId, ignoreCollected, includeCollectedPrereqs));
 
-        public static List<MeldPlan> GetNeededItemMeldPlans(uint itemId, List<Gearset> gearsets)
+        public static List<MeldPlan> GetNeededItemMeldPlans(uint itemId, List<Gearset> gearsets, bool includeAsPrerequisite)
         {
             var neededMeldPlans = new List<MeldPlan>();
 
@@ -61,7 +61,7 @@ namespace BisBuddy.Gear
                 foreach (var gearpiece in gearset.Gearpieces)
                 {
                     // this gearpiece doesn't need this item
-                    if (gearpiece.NeedsItemId(itemId, false, true) == 0)
+                    if (!gearpiece.NeedsItemId(itemId, false, true, includeAsPrerequisite))
                         continue;
 
                     // look at what materia is needed for this gearpiece
@@ -78,7 +78,7 @@ namespace BisBuddy.Gear
             return neededMeldPlans;
         }
 
-        public static HashSet<string> GetUnmeldedItemNames(List<Gearset> gearsets)
+        public static HashSet<string> GetUnmeldedItemNames(List<Gearset> gearsets, bool includePrerequisites)
         {
             // return list of meldable item names for gearpieces that aren't fully melded
             var itemNames = new HashSet<string>();
@@ -96,7 +96,7 @@ namespace BisBuddy.Gear
                     itemNames.Add(gearpiece.ItemName);
 
                     // try to find any meldable items in prereq tree and add those names
-                    if (gearpiece.PrerequisiteTree != null)
+                    if (gearpiece.PrerequisiteTree != null && includePrerequisites)
                         itemNames.UnionWith(gearpiece.PrerequisiteTree.MeldableItemNames());
                 }
             }

--- a/BisBuddy/Gear/Gearset.Util.cs
+++ b/BisBuddy/Gear/Gearset.Util.cs
@@ -42,15 +42,14 @@ namespace BisBuddy.Gear
 
                 foreach (var gearpiece in gearset.Gearpieces)
                 {
-                    // item we have isn't this gearpiece
-                    if (gearpiece.ItemId != itemId) continue;
+                    // this gearpiece doesn't need this item
+                    if (gearpiece.NeedsItemId(itemId, false, true) == 0)
+                        continue;
 
                     // look at what materia is needed for this gearpiece
                     var gearpieceMateria = new List<Materia>();
                     foreach (var materia in gearpiece.ItemMateria)
-                    {
                         gearpieceMateria.Add(materia);
-                    }
 
                     // if there are any melds needed, add this 'meld plan' to the list
                     if (gearpieceMateria.Any(m => !m.IsMelded))
@@ -61,28 +60,30 @@ namespace BisBuddy.Gear
             return neededMeldPlans;
         }
 
-        public static List<Gearpiece> GetUnmeldedGearpieces(List<Gearset> gearsets)
+        public static HashSet<string> GetUnmeldedItemNames(List<Gearset> gearsets)
         {
-            // return list of gearpieces that are not fully melded
-            var gearpieces = new List<Gearpiece>();
+            // return list of meldable item names for gearpieces that aren't fully melded
+            var itemNames = new HashSet<string>();
 
             foreach (var gearset in gearsets)
             {
                 if (!gearset.IsActive) continue;
                 foreach (var gearpiece in gearset.Gearpieces)
                 {
-                    foreach (var materia in gearpiece.ItemMateria)
-                    {
-                        if (!materia.IsMelded)
-                        {
-                            gearpieces.Add(gearpiece);
-                            break;
-                        }
-                    }
+                    // all gearpiece materia is melded, no melds required
+                    if (gearpiece.ItemMateria.All(m => m.IsMelded))
+                        continue;
+
+                    // add item itself to list
+                    itemNames.Add(gearpiece.ItemName);
+
+                    // try to find any meldable items in prereq tree and add those names
+                    if (gearpiece.PrerequisiteTree != null)
+                        itemNames.UnionWith(gearpiece.PrerequisiteTree.MeldableItemNames());
                 }
             }
 
-            return gearpieces;
+            return itemNames;
         }
 
         public static List<Gearpiece> GetGearpiecesFromGearsets(List<Gearset> sourceGearsets)

--- a/BisBuddy/Gear/Prerequisites/PrerequesiteAndNode.cs
+++ b/BisBuddy/Gear/Prerequisites/PrerequesiteAndNode.cs
@@ -113,6 +113,13 @@ namespace BisBuddy.Gear.Prerequisites
                 .ToList();
         }
 
+        public HashSet<string> MeldableItemNames()
+        {
+            return PrerequisiteTree
+                .SelectMany(p => p.MeldableItemNames())
+                .ToHashSet();
+        }
+
         public string GroupKey()
         {
             return $"""

--- a/BisBuddy/Gear/Prerequisites/PrerequesiteAtomNode.cs
+++ b/BisBuddy/Gear/Prerequisites/PrerequesiteAtomNode.cs
@@ -13,6 +13,7 @@ namespace BisBuddy.Gear.Prerequisites
         public string NodeId { get; init; }
         public uint ItemId { get; set; }
         public string ItemName { get; set; }
+        public bool IsMeldable { get; set; } = false;
         public PrerequisiteNodeSourceType SourceType { get; set; }
         public List<PrerequisiteNode> PrerequisiteTree { get; set; }
 
@@ -37,7 +38,8 @@ namespace BisBuddy.Gear.Prerequisites
             PrerequisiteNodeSourceType sourceType,
             bool isCollected = false,
             bool isManuallyCollected = false,
-            string? nodeId = null
+            string? nodeId = null,
+            bool isMeldable = false
             )
         {
             NodeId = nodeId ?? Guid.NewGuid().ToString();
@@ -47,6 +49,7 @@ namespace BisBuddy.Gear.Prerequisites
             PrerequisiteTree = prerequisiteTree ?? [];
             IsCollected = isCollected;
             IsManuallyCollected = isManuallyCollected;
+            IsMeldable = isMeldable;
         }
 
         public void SetCollected(bool collected, bool manualToggle)
@@ -140,6 +143,18 @@ namespace BisBuddy.Gear.Prerequisites
             return PrerequisiteTree
                 .SelectMany(p => p.ManuallyCollectedItemIds())
                 .ToList();
+        }
+
+        public HashSet<string> MeldableItemNames()
+        {
+            var prereqNames = PrerequisiteTree
+                .SelectMany(p => p.MeldableItemNames())
+                .ToHashSet();
+
+            if (IsMeldable)
+                prereqNames.Add(ItemName);
+
+            return prereqNames;
         }
 
         public string GroupKey()

--- a/BisBuddy/Gear/Prerequisites/PrerequesiteNode.cs
+++ b/BisBuddy/Gear/Prerequisites/PrerequesiteNode.cs
@@ -21,6 +21,7 @@ namespace BisBuddy.Gear.Prerequisites
         public PrerequisiteNode? AssignItemId(uint itemId);
         public List<uint> ManuallyCollectedItemIds();
         public int PrerequisiteCount();
+        public HashSet<string> MeldableItemNames();
         public string GroupKey();
     }
 }

--- a/BisBuddy/Gear/Prerequisites/PrerequesiteOrNode.cs
+++ b/BisBuddy/Gear/Prerequisites/PrerequesiteOrNode.cs
@@ -84,6 +84,13 @@ namespace BisBuddy.Gear.Prerequisites
                 .ToList();
         }
 
+        public HashSet<string> MeldableItemNames()
+        {
+            return PrerequisiteTree
+                .SelectMany(p => p.MeldableItemNames())
+                .ToHashSet();
+        }
+
         public string GroupKey()
         {
             return $"""

--- a/BisBuddy/Items/ItemData.cs
+++ b/BisBuddy/Items/ItemData.cs
@@ -230,6 +230,19 @@ namespace BisBuddy.Items
 
             return materiaItem.RowId;
         }
+        
+        /// <summary>
+        /// Returns if an item can have materia attached to it
+        /// </summary>
+        /// <param name="itemId">The item id to check</param>
+        /// <returns>If it can be melded. If invalid item id, returns false.</returns>
+        public bool ItemIsMeldable(uint itemId)
+        {
+            if (!ItemSheet.TryGetRow(itemId, out var itemRow))
+                return false;
+
+            return itemRow.MateriaSlotCount > 0;
+        }
 
         /// <summary>   
         /// Extends the given PrerequisiteNode with new leaves at the node's direct child level according to current

--- a/BisBuddy/Resources/Resource.Designer.cs
+++ b/BisBuddy/Resources/Resource.Designer.cs
@@ -232,6 +232,15 @@ namespace BisBuddy.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Collected Only.
+        /// </summary>
+        internal static string HighlightCollectedItemMateriaCheckbox {
+            get {
+                return ResourceManager.GetString("HighlightCollectedItemMateriaCheckbox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Highlight Color.
         /// </summary>
         internal static string HighlightColorButtonLabel {
@@ -376,6 +385,33 @@ namespace BisBuddy.Resources {
         internal static string HighlightNextMateriaHelp {
             get {
                 return ResourceManager.GetString("HighlightNextMateriaHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Meld Prerequisites.
+        /// </summary>
+        internal static string HighlightPrerequisiteMateriaCheckbox {
+            get {
+                return ResourceManager.GetString("HighlightPrerequisiteMateriaCheckbox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Whether prerequisites should be marked for melding if they have materia slots and the gearpiece they are for requires melds
+        ///
+        ///When ON: Prerequisites will be highlighted when melding materia, with the materia highlighted being the ones for the final gearpiece
+        ///When OFF: Only the main gearpiece will be highlighted when melding materia.
+        ///
+        ///Example
+        ///Gearpiece (unobtained): Augmented Historia Ring of Casting [+54 DET, +54 CRT]
+        ///Prerequisite (obtained): Historia Ring of Casting
+        ///
+        ///When ON: When melding, the Hist [rest of string was truncated]&quot;;.
+        /// </summary>
+        internal static string HighlightPrerequisiteMateriaHelp {
+            get {
+                return ResourceManager.GetString("HighlightPrerequisiteMateriaHelp", resourceCulture);
             }
         }
         

--- a/BisBuddy/Resources/Resource.resx
+++ b/BisBuddy/Resources/Resource.resx
@@ -392,4 +392,23 @@ Gearpiece needs the following melds: [+36 CRT, +36 DET]
 When ON: +36 CRT is highlighted
 When OFF: +36 CRT and +36 DET are highlighted</value>
   </data>
+  <data name="HighlightCollectedItemMateriaCheckbox" xml:space="preserve">
+    <value>Collected Only</value>
+  </data>
+  <data name="HighlightPrerequisiteMateriaCheckbox" xml:space="preserve">
+    <value>Meld Prerequisites</value>
+  </data>
+  <data name="HighlightPrerequisiteMateriaHelp" xml:space="preserve">
+    <value>Whether prerequisites should be marked for melding if they have materia slots and the gearpiece they are for requires melds
+
+When ON: Prerequisites will be highlighted when melding materia, with the materia highlighted being the ones for the final gearpiece
+When OFF: Only the main gearpiece will be highlighted when melding materia.
+
+Example
+Gearpiece (unobtained): Augmented Historia Ring of Casting [+54 DET, +54 CRT]
+Prerequisite (obtained): Historia Ring of Casting
+
+When ON: When melding, the Historia Ring of Casting is highlighted and the materia highlighted for it is [+54 DET, +54 CRT]
+When OFF: The Historia Ring of Casting is not highlighted.</value>
+  </data>
 </root>

--- a/BisBuddy/Windows/ConfigWindow.cs
+++ b/BisBuddy/Windows/ConfigWindow.cs
@@ -111,7 +111,7 @@ public class ConfigWindow : Window, IDisposable
             var curLoc = ImGui.GetCursorScreenPos();
             var col = ImGui.GetColorU32(new Vector4(1, 1, 1, 1));
             var halfButtonHeight = (ImGui.CalcTextSize("HI").Y / 2) + ImGui.GetStyle().FramePadding.Y;
-            drawList.AddLine(curLoc + new Vector2(10, 0), curLoc + new Vector2(10, halfButtonHeight), col, 2);
+            drawList.AddLine(curLoc + new Vector2(10, 0), curLoc + new Vector2(10, (halfButtonHeight * 3) + 5), col, 2);
             drawList.AddLine(curLoc + new Vector2(10, halfButtonHeight), curLoc + new Vector2(20, halfButtonHeight), col, 2);
 
             using (ImRaii.PushIndent(25.0f, scaled: false))
@@ -124,6 +124,22 @@ public class ConfigWindow : Window, IDisposable
                 }
                 ImGui.SameLine();
                 ImGuiComponents.HelpMarker(Resource.HighlightNextMateriaHelp);
+            }
+
+            drawList = ImGui.GetWindowDrawList();
+            curLoc = ImGui.GetCursorScreenPos();
+            drawList.AddLine(curLoc + new Vector2(10, halfButtonHeight), curLoc + new Vector2(20, halfButtonHeight), col, 2);
+
+            using (ImRaii.PushIndent(25.0f, scaled: false))
+            {
+                var highlightPrerequisiteMateria = configuration.HighlightPrerequisiteMateria;
+                if (ImGui.Checkbox(Resource.HighlightPrerequisiteMateriaCheckbox, ref highlightPrerequisiteMateria))
+                {
+                    configuration.HighlightPrerequisiteMateria = highlightPrerequisiteMateria;
+                    plugin.SaveGearsetsWithUpdate(false);
+                }
+                ImGui.SameLine();
+                ImGuiComponents.HelpMarker(Resource.HighlightPrerequisiteMateriaHelp);
             }
         }
 


### PR DESCRIPTION
Adds an optional feature where items (that are meldable) that are prerequisites for gearpieces. Shows the gearpiece's meld when that prerequisite is in the materia attach window