### PR TITLE
Obtained item materia highlight

### DIFF
--- a/BisBuddy/Configuration.cs
+++ b/BisBuddy/Configuration.cs
@@ -24,7 +24,7 @@ public class Configuration : IPluginConfiguration
     public bool HighlightShops { get; set; } = true;
     public bool HighlightMateriaMeld { get; set; } = true;
     public bool HighlightNextMateria { get; set; } = false;
-    public bool HighlightCollectedItemMateria { get; set; } = false;
+    public bool HighlightUncollectedItemMateria { get; set; } = true;
     public bool HighlightPrerequisiteMateria { get; set; } = true;
     public bool HighlightInventories { get; set; } = true;
     public bool HighlightMarketboard { get; set; } = true;

--- a/BisBuddy/EventListeners/AddonEventListeners/Containers/ContainerEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/Containers/ContainerEventListener.cs
@@ -128,7 +128,13 @@ namespace BisBuddy.EventListeners.AddonEventListeners.Containers
                 var item = items[i];
                 var itemId = Plugin.ItemData.ConvertItemIdToHq(item.ItemId);
 
-                if (Gearset.GearsetsNeedItemId(itemId, Plugin.Gearsets, includeCollectedPrereqs: true))
+                if (Gearset.GearsetsNeedItemId(
+                        itemId,
+                        Plugin.Gearsets,
+                        includeCollectedPrereqs: true,
+                        includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria
+                        )
+                    )
                     neededItemIndexes.Add(i);
             }
         }

--- a/BisBuddy/EventListeners/AddonEventListeners/ItemSearchEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ItemSearchEventListener.cs
@@ -86,8 +86,8 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                     var hqItemId = Plugin.ItemData.ConvertItemIdToHq(nqItemId);
 
                     var nqOrHqNeeded = (
-                        Gearset.GearsetsNeedItemId(nqItemId, Plugin.Gearsets) // either the NQ is needed
-                        || Gearset.GearsetsNeedItemId(hqItemId, Plugin.Gearsets) // or HQ is needed
+                        Gearset.GearsetsNeedItemId(nqItemId, Plugin.Gearsets, includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria) // either the NQ is needed
+                        || Gearset.GearsetsNeedItemId(hqItemId, Plugin.Gearsets, includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria) // or HQ is needed
                         );
                     if (nqOrHqNeeded) // needed at some level
                     {

--- a/BisBuddy/EventListeners/AddonEventListeners/NeedGreedEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/NeedGreedEventListener.cs
@@ -43,7 +43,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners
                 for (var itemIdx = 0; itemIdx < addon->NumItems; itemIdx++)
                 {
                     var lootItem = addon->Items[itemIdx];
-                    if (Gearset.GearsetsNeedItemId(lootItem.ItemId, Plugin.Gearsets))
+                    if (Gearset.GearsetsNeedItemId(lootItem.ItemId, Plugin.Gearsets, includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria))
                         itemIndexesToHighlight.Add(itemIdx);
                 }
 

--- a/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeEventListener.cs
+++ b/BisBuddy/EventListeners/AddonEventListeners/ShopExchange/ShopExchangeEventListener.cs
@@ -130,7 +130,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
                 shieldInAtkValues = true;
 
                 // add if needed
-                if (Gearset.GearsetsNeedItemId(endOfItemIdList.UInt, Plugin.Gearsets))
+                if (Gearset.GearsetsNeedItemId(endOfItemIdList.UInt, Plugin.Gearsets, includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria))
                     neededShopItemIndexes.Add(AddonShieldIndex);
             }
 
@@ -147,7 +147,7 @@ namespace BisBuddy.EventListeners.AddonEventListeners.ShopExchange
                     ? 1  // shield visible and idx after where shield goes
                     : 0; // either shield not visible or before where shield goes
 
-                if (Gearset.GearsetsNeedItemId(itemId, Plugin.Gearsets))
+                if (Gearset.GearsetsNeedItemId(itemId, Plugin.Gearsets, includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria))
                 {
                     var filteredIndex = getFilteredIndex(i, atkValues);
                     if (filteredIndex >= 0) neededShopItemIndexes.Add(filteredIndex + shieldOffset);

--- a/BisBuddy/EventListeners/InventoryItemEventListener.cs
+++ b/BisBuddy/EventListeners/InventoryItemEventListener.cs
@@ -1,4 +1,5 @@
 using BisBuddy.Gear;
+using Dalamud.Game.Addon.Lifecycle.AddonArgTypes;
 using Dalamud.Game.Inventory;
 using Dalamud.Game.Inventory.InventoryEventArgTypes;
 using System;
@@ -48,7 +49,13 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (!Gearset.GearsetsNeedItemId(addedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
+                if (!Gearset.GearsetsNeedItemId(
+                        addedArgs.Item.ItemId,
+                        Plugin.Gearsets,
+                        ignoreCollected: false,
+                        includeCollectedPrereqs: true,
+                        includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria
+                    ))
                     return;
 
                 // added to type we track, update gearsets
@@ -71,7 +78,13 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (!Gearset.GearsetsNeedItemId(removedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
+                if (!Gearset.GearsetsNeedItemId(
+                        removedArgs.Item.ItemId,
+                        Plugin.Gearsets,
+                        ignoreCollected: false,
+                        includeCollectedPrereqs: true,
+                        includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria
+                    ))
                     return;
 
                 // removed from type we track, update gearsets
@@ -94,7 +107,13 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (!Gearset.GearsetsNeedItemId(changedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
+                if (!Gearset.GearsetsNeedItemId(
+                        changedArgs.Item.ItemId,
+                        Plugin.Gearsets,
+                        ignoreCollected: false,
+                        includeCollectedPrereqs: true,
+                        includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria
+                    ))
                     return;
 
                 // changed in a type we track, update gearsets
@@ -117,7 +136,13 @@ namespace BisBuddy.EventListeners
                     return;
 
                 // item not needed in any gearsets, ignore
-                if (!Gearset.GearsetsNeedItemId(movedArgs.Item.ItemId, Plugin.Gearsets, ignoreCollected: false, includeCollectedPrereqs: true))
+                if (!Gearset.GearsetsNeedItemId(
+                        movedArgs.Item.ItemId,
+                        Plugin.Gearsets,
+                        ignoreCollected: false,
+                        includeCollectedPrereqs: true,
+                        includeUncollectedItemMateria: Plugin.Configuration.HighlightUncollectedItemMateria
+                    ))
                     return;
 
                 // moved untracked -> tracked or tracked -> untracked, update gearsets

--- a/BisBuddy/Gear/Gearpiece.cs
+++ b/BisBuddy/Gear/Gearpiece.cs
@@ -82,7 +82,13 @@ namespace BisBuddy.Gear
                 PrerequisiteTree.SetCollected(false, manualToggle);
         }
 
-        public bool NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs, bool includeAsPrerequisite = true)
+        public bool NeedsItemId(
+            uint candidateItemId,
+            bool ignoreCollected,
+            bool includeCollectedPrereqs,
+            bool includeUncollectedItemMateria,
+            bool includeAsPrerequisite = true
+            )
         {
             // not a real item, can't be needed
             if (candidateItemId == 0)
@@ -96,7 +102,8 @@ namespace BisBuddy.Gear
             if (candidateItemId == ItemId)
                 return true;
 
-            var neededAsMateria = ItemMateria.Any(materia => (!materia.IsMelded || !ignoreCollected) && candidateItemId == materia.ItemId);
+            var neededAsMateria = (includeUncollectedItemMateria || IsCollected)
+                && ItemMateria.Any(materia => (!materia.IsMelded || !ignoreCollected) && candidateItemId == materia.ItemId);
             var neededAsPrerequisite = includeAsPrerequisite
                 && (PrerequisiteTree?.ItemNeededCount(candidateItemId, !includeCollectedPrereqs && ignoreCollected) ?? 0) > 0;
 

--- a/BisBuddy/Gear/Gearset.Util.cs
+++ b/BisBuddy/Gear/Gearset.Util.cs
@@ -44,9 +44,10 @@ namespace BisBuddy.Gear
             uint itemId,
             List<Gearset> gearsets,
             bool ignoreCollected = true,
-            bool includeCollectedPrereqs = false
+            bool includeCollectedPrereqs = false,
+            bool includeUncollectedItemMateria = true
             ) =>
-            gearsets.Any(gearset => gearset.NeedsItemId(itemId, ignoreCollected, includeCollectedPrereqs));
+            gearsets.Any(gearset => gearset.NeedsItemId(itemId, ignoreCollected, includeCollectedPrereqs, includeUncollectedItemMateria));
 
         public static List<MeldPlan> GetNeededItemMeldPlans(uint itemId, List<Gearset> gearsets, bool includeAsPrerequisite)
         {
@@ -61,7 +62,7 @@ namespace BisBuddy.Gear
                 foreach (var gearpiece in gearset.Gearpieces)
                 {
                     // this gearpiece doesn't need this item
-                    if (!gearpiece.NeedsItemId(itemId, false, true, includeAsPrerequisite))
+                    if (!gearpiece.NeedsItemId(itemId, false, true, true, includeAsPrerequisite: includeAsPrerequisite))
                         continue;
 
                     // look at what materia is needed for this gearpiece

--- a/BisBuddy/Gear/Gearset.cs
+++ b/BisBuddy/Gear/Gearset.cs
@@ -62,7 +62,7 @@ namespace BisBuddy.Gear
             return satisfiedGearpieces;
         }
 
-        public bool NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs) =>
-            IsActive && Gearpieces.Any(gearpiece => gearpiece.NeedsItemId(candidateItemId, ignoreCollected, includeCollectedPrereqs));
+        public bool NeedsItemId(uint candidateItemId, bool ignoreCollected, bool includeCollectedPrereqs, bool includeUncollectedItemMateria) =>
+            IsActive && Gearpieces.Any(gearpiece => gearpiece.NeedsItemId(candidateItemId, ignoreCollected, includeCollectedPrereqs, includeUncollectedItemMateria));
     }
 }

--- a/BisBuddy/Items/ItemData.cs
+++ b/BisBuddy/Items/ItemData.cs
@@ -246,19 +246,6 @@ namespace BisBuddy.Items
             return itemRow.MateriaSlotCount > 0;
         }
 
-        /// <summary>
-        /// Returns if an item can have materia attached to it
-        /// </summary>
-        /// <param name="itemId">The item id to check</param>
-        /// <returns>If it can be melded. If invalid item id, returns false.</returns>
-        public bool ItemIsMeldable(uint itemId)
-        {
-            if (!ItemSheet.TryGetRow(itemId, out var itemRow))
-                return false;
-
-            return itemRow.MateriaSlotCount > 0;
-        }
-
         /// <summary>   
         /// Extends the given PrerequisiteNode with new leaves at the node's direct child level according to current
         /// data. Used on config loading to automatically add new prerequisite information that wasn't available when the gearset

--- a/BisBuddy/Resources/Resource.Designer.cs
+++ b/BisBuddy/Resources/Resource.Designer.cs
@@ -434,6 +434,27 @@ namespace BisBuddy.Resources {
         }
         
         /// <summary>
+        ///   Looks up a localized string similar to Uncollected Item Materia.
+        /// </summary>
+        internal static string HighlightUncollectedItemMateriaCheckbox {
+            get {
+                return ResourceManager.GetString("HighlightUncollectedItemMateriaCheckbox", resourceCulture);
+            }
+        }
+        
+        /// <summary>
+        ///   Looks up a localized string similar to Whether materia needed for gearpieces that are not yet collected should be highlighted.
+        ///
+        ///When ON: If a gearpiece isn&apos;t collected, its materia will not be highlighted anywhere
+        ///When OFF: Materia needed for gearpieces will be highlighted regardless of collected status.
+        /// </summary>
+        internal static string HighlightUncollectedItemMateriaHelp {
+            get {
+                return ResourceManager.GetString("HighlightUncollectedItemMateriaHelp", resourceCulture);
+            }
+        }
+        
+        /// <summary>
         ///   Looks up a localized string similar to Gearset sheet link from Etro.gg
         ///ex: https://etro.gg/gearset/4b5f4ed3-4832-4fd5-b134-3429ea8caf37.
         /// </summary>

--- a/BisBuddy/Resources/Resource.resx
+++ b/BisBuddy/Resources/Resource.resx
@@ -411,4 +411,13 @@ Prerequisite (obtained): Historia Ring of Casting
 When ON: When melding, the Historia Ring of Casting is highlighted and the materia highlighted for it is [+54 DET, +54 CRT]
 When OFF: The Historia Ring of Casting is not highlighted.</value>
   </data>
+  <data name="HighlightUncollectedItemMateriaCheckbox" xml:space="preserve">
+    <value>Uncollected Item Materia</value>
+  </data>
+  <data name="HighlightUncollectedItemMateriaHelp" xml:space="preserve">
+    <value>Whether materia needed for gearpieces that are not yet collected should be highlighted.
+
+When ON: If a gearpiece isn't collected, its materia will not be highlighted anywhere
+When OFF: Materia needed for gearpieces will be highlighted regardless of collected status</value>
+  </data>
 </root>

--- a/BisBuddy/Windows/ConfigWindow.cs
+++ b/BisBuddy/Windows/ConfigWindow.cs
@@ -182,6 +182,17 @@ public class ConfigWindow : Window, IDisposable
         ImGui.SameLine();
         ImGuiComponents.HelpMarker(Resource.HighlightItemTooltipsHelp);
 
+        //UNCOLLECTED MATERIA HIGHLIGHTING
+        var highlightUncollectedItemMateria = configuration.HighlightUncollectedItemMateria;
+        if (ImGui.Checkbox(Resource.HighlightUncollectedItemMateriaCheckbox, ref highlightUncollectedItemMateria))
+        {
+            configuration.HighlightUncollectedItemMateria = highlightUncollectedItemMateria;
+            plugin.SaveGearsetsWithUpdate(false);
+
+        }
+        ImGui.SameLine();
+        ImGuiComponents.HelpMarker(Resource.HighlightUncollectedItemMateriaHelp);
+
         ImGui.Spacing();
         ImGui.Separator();
         ImGui.Text(Resource.ConfigInventorySectionHeader);


### PR DESCRIPTION
Add a setting to control whether materia for gearpieces that are not yet collected should be considered needed. This is to help avoid cluttering shops and such with materia that you won't need until much later. Thanks to neongray on discord for the suggestion!