### PR TITLE
feat: Add Optional Upgrades tracking system

### DIFF
--- a/BisBuddy/Plugin.cs
+++ b/BisBuddy/Plugin.cs
@@ -254,6 +254,9 @@ public sealed partial class Plugin : IDalamudPlugin
                 // plugin configuration
                 builder.RegisterType<ConfigurationService>().AsImplementedInterfaces().SingleInstance();
 
+                // optional upgrades
+                builder.RegisterType<OptionalUpgradeService>().AsImplementedInterfaces().SingleInstance();
+
                 // commands
                 builder.RegisterType<CommandService>().AsImplementedInterfaces().SingleInstance();
 

--- a/BisBuddy/Services/Addon/AddonService.cs
+++ b/BisBuddy/Services/Addon/AddonService.cs
@@ -29,6 +29,7 @@ namespace BisBuddy.Services.Addon
         protected readonly IItemDataService itemDataService = dependencies.ItemDataService;
         protected readonly IConfigurationService configurationService = dependencies.ConfigurationService;
         protected readonly IDebugService debugService = dependencies.DebugService;
+        protected readonly IOptionalUpgradeService optionalUpgradeService = dependencies.OptionalUpgradeService;
 
         private static readonly HighlightColor NullColor = new(0.0f, 0.0f, 0.0f, 0.393f);
         private readonly Dictionary<nint, (NodeBase Node, HighlightColor Color)> customNodes = [];

--- a/BisBuddy/Services/Addon/AddonServiceDependencies.cs
+++ b/BisBuddy/Services/Addon/AddonServiceDependencies.cs
@@ -13,7 +13,8 @@ namespace BisBuddy.Services.Addon
         IGearsetsService gearsetsService,
         IItemDataService itemDataService,
         IConfigurationService configurationService,
-        IDebugService debugService
+        IDebugService debugService,
+        IOptionalUpgradeService optionalUpgradeService
         ) where T : class
     {
         public readonly ITypedLogger<T> logger = logger;
@@ -24,5 +25,6 @@ namespace BisBuddy.Services.Addon
         public readonly IItemDataService ItemDataService = itemDataService;
         public readonly IConfigurationService ConfigurationService = configurationService;
         public readonly IDebugService DebugService = debugService;
+        public readonly IOptionalUpgradeService OptionalUpgradeService = optionalUpgradeService;
     }
 }

--- a/BisBuddy/Services/Addon/Containers/ContainerService.cs
+++ b/BisBuddy/Services/Addon/Containers/ContainerService.cs
@@ -115,6 +115,10 @@ namespace BisBuddy.Services.Addon.Containers
                     includeCollectedPrereqs: true,
                     includeObtainable: true
                     );
+                if (itemColor is null && configurationService.HighlightOptionalUpgrades)
+                {
+                    itemColor = optionalUpgradeService.GetUpgradeColor(item.ItemId);
+                }
 
                 if (itemColor is not null)
                     neededItemColors.Add(i, itemColor);

--- a/BisBuddy/Services/Addon/ItemDetailService.cs
+++ b/BisBuddy/Services/Addon/ItemDetailService.cs
@@ -58,6 +58,7 @@ namespace BisBuddy.Services.Addon
 
         // list of gearset names that need the currently hovered item
         private List<(Gearset gearset, int countNeeded)> neededGearsets = [];
+        private bool isOptionalUpgrade = false;
 
         // Doesn't really use a node color, use this as a standin
         private static readonly HighlightColor TextNodeColor = new(0.0f, 0.0f, 0.0f, 1.0f);
@@ -79,6 +80,7 @@ namespace BisBuddy.Services.Addon
             gearsetsService.OnGearsetsChange -= handleManualUpdate;
             gameGui.HoveredItemChanged -= handleHoveredItemChanged;
             neededGearsets = [];
+            isOptionalUpgrade = false;
         }
 
         protected override bool isEnabledFromConfig
@@ -114,7 +116,7 @@ namespace BisBuddy.Services.Addon
                     return;
 
                 // update node visibility
-                if (neededGearsets.Count == 0)
+                if (neededGearsets.Count == 0 && !isOptionalUpgrade)
                 {
                     setNodeVisibility(false);
                     return;
@@ -157,7 +159,15 @@ namespace BisBuddy.Services.Addon
                 ? CustomNodeMaxGearsetNameLength
                 : CustomNodeGearsetNameLengthShortList;
 
-            // add gearset names to output string
+            if (isOptionalUpgrade && neededGearsets.Count == 0)
+            {
+                startStr = "[Upgrade]";
+                outputStr = startStr;
+                neededStrings = [(startStr, string.Empty, string.Empty)];
+            }
+            else
+            {
+                // add gearset names to output string
             for (var i = 0; i < neededGearsets.Count; i++)
             {
                 var fullGearsetName = neededGearsets[i].gearset.Name;
@@ -196,6 +206,7 @@ namespace BisBuddy.Services.Addon
                     neededStrings.Add((string.Empty, string.Empty, $"+{neededGearsets.Count - i}{endStr}"));
                     break;
                 }
+            }
             }
 
             using var outputBuilder = new RentedSeStringBuilder();
@@ -254,15 +265,22 @@ namespace BisBuddy.Services.Addon
                 includeCollectedPrereqs: isInternalItem
                 );
 
-            if (itemRequirements is null || itemRequirements.Count == 0)
+            var newIsOptionalUpgrade = false;
+            if (configurationService.HighlightOptionalUpgrades)
             {
-                if (neededGearsets.Count == 0)
+                newIsOptionalUpgrade = optionalUpgradeService.GetUpgradeColor(itemId) is not null;
+            }
+
+            if ((itemRequirements is null || itemRequirements.Count == 0) && !newIsOptionalUpgrade)
+            {
+                if (neededGearsets.Count == 0 && isOptionalUpgrade == false)
                     return false;
                 neededGearsets = [];
+                isOptionalUpgrade = false;
                 return true;
             }
 
-            var newNeededGearsets = itemRequirements
+            var newNeededGearsets = (itemRequirements ?? [])
                 .GroupBy(requirement => requirement.Gearset)
                 .Select(group => (Gearset: group.Key, countNeeded: group.Count()))
                 .ToList();
@@ -270,10 +288,12 @@ namespace BisBuddy.Services.Addon
             if (
                 newNeededGearsets.Count == neededGearsets.Count
                 && newNeededGearsets.SequenceEqual(neededGearsets)
+                && isOptionalUpgrade == newIsOptionalUpgrade
                 )
                 return false;
 
             neededGearsets = newNeededGearsets;
+            isOptionalUpgrade = newIsOptionalUpgrade;
             return true;
         }
 

--- a/BisBuddy/Services/Addon/NeedGreedService.cs
+++ b/BisBuddy/Services/Addon/NeedGreedService.cs
@@ -45,6 +45,11 @@ namespace BisBuddy.Services.Addon
                 {
                     var lootItem = addon->Items[itemIdx];
                     var itemColor = gearsetsService.GetRequirementColor(lootItem.ItemId);
+                    
+                    if (itemColor is null && configurationService.HighlightOptionalUpgrades)
+                    {
+                        itemColor = optionalUpgradeService.GetUpgradeColor(lootItem.ItemId);
+                    }
 
                     if (itemColor is not null)
                         itemIndexesToHighlight.Add(itemIdx, itemColor);

--- a/BisBuddy/Services/Addon/ShopExchange/ShopExchangeService.cs
+++ b/BisBuddy/Services/Addon/ShopExchange/ShopExchangeService.cs
@@ -119,7 +119,7 @@ namespace BisBuddy.Services.Addon.ShopExchange
             }
             catch (Exception ex)
             {
-                Log.Warning(ex, "Error in handlePreDraw");
+                logger.Error(ex, $"Error in handlePreDraw");
             }
         }
 
@@ -130,9 +130,13 @@ namespace BisBuddy.Services.Addon.ShopExchange
             var shopItemCount = atkValues[AtkValueItemCountIndex].Int;
             var maxItemIndex = AtkValueItemIdListStartingIndex + shopItemCount;
 
-            if (atkValues.Length <= maxItemIndex)
+            if (shopItemCount <= 0 || atkValues.Length <= maxItemIndex)
             {
-                throw new Exception($"{AddonName} AtkValue list is too short ({atkValues.Length}, {maxItemIndex})");
+
+                if (atkValues.Length <= maxItemIndex)
+                {
+                    throw new Exception($"{AddonName} AtkValue list is too short ({atkValues.Length}, {maxItemIndex})");
+                }
             }
 
             // handle INDENTED shields
@@ -154,6 +158,11 @@ namespace BisBuddy.Services.Addon.ShopExchange
                     endOfItemIdList.UInt,
                     includeObtainable: true
                     );
+                if (shopItemColor is null && configurationService.HighlightOptionalUpgrades)
+                {
+                    shopItemColor = optionalUpgradeService.GetUpgradeColor(endOfItemIdList.UInt);
+                }
+
                 if (shopItemColor is not null)
                     neededShopItemIndexColors.Add(AddonShieldIndex, shopItemColor);
             }
@@ -168,6 +177,9 @@ namespace BisBuddy.Services.Addon.ShopExchange
                 }
                 ;
                 var itemId = itemIdAtkValue.UInt;
+                if (itemId > 1000000) itemId %= 1000000;
+                else if (itemId > 500000) itemId %= 500000;
+
                 var shieldOffset = shieldInAtkValues && i >= AddonShieldIndex
                     ? 1  // shield visible and idx after where shield goes
                     : 0; // either shield not visible or before where shield goes
@@ -176,6 +188,10 @@ namespace BisBuddy.Services.Addon.ShopExchange
                     itemId,
                     includeObtainable: true
                     );
+                if (itemColor is null && configurationService.HighlightOptionalUpgrades)
+                {
+                    itemColor = optionalUpgradeService.GetUpgradeColor(itemId);
+                }
 
                 if (itemColor is not null)
                 {
@@ -197,13 +213,18 @@ namespace BisBuddy.Services.Addon.ShopExchange
             */
 
             if (atkValues.Length <= AtkValueFilteredItemsListStartingIndex)
+            {
                 return -1;
+            }
 
             // not visible
             if (
                 atkValues[index + AtkValueFilteredItemsListStartingIndex].Int
                 > AtkValueFilteredItemsListVisibleMaxValue
-                ) return -1;
+                )
+            {
+                return -1;
+            }
 
             var itemCount = atkValues[AtkValueItemCountIndex];
             var visibleCount = 0;

--- a/BisBuddy/Services/Configuration/Configuration.cs
+++ b/BisBuddy/Services/Configuration/Configuration.cs
@@ -22,6 +22,7 @@ public class Configuration : IConfigurationProperties
     public bool HighlightCollectedInInventory { get; set; } = true;
     public bool HighlightMarketboard { get; set; } = true;
     public bool AnnotateTooltips { get; set; } = true;
+    public bool HighlightOptionalUpgrades { get; set; } = true;
     public bool AutoCompleteItems { get; set; } = true;
     public bool AutoScanInventory { get; set; } = true;
     public bool PluginUpdateInventoryScan { get; set; } = true;
@@ -30,6 +31,7 @@ public class Configuration : IConfigurationProperties
 
     public bool BrightListItemHighlighting { get; set; } = true;
     public HighlightColor DefaultHighlightColor { get; set; } = new(0.0f, 1.0f, 0.0f, 0.393f);
+    public HighlightColor OptionalUpgradeColor { get; set; } = new(0.0f, 0.5f, 1.0f, 0.393f); // Blueish
     public UiTheme UiTheme { get; set; } = new();
 
     // DEBUGGING
@@ -51,6 +53,7 @@ public interface IConfigurationProperties : IPluginConfiguration
     bool HighlightCollectedInInventory { get; set; }
     bool HighlightMarketboard { get; set; }
     bool AnnotateTooltips { get; set; }
+    bool HighlightOptionalUpgrades { get; set; }
     bool AutoCompleteItems { get; set; }
     bool AutoScanInventory { get; set; }
     bool PluginUpdateInventoryScan { get; set; }
@@ -58,6 +61,7 @@ public interface IConfigurationProperties : IPluginConfiguration
     bool AllowGearpiecesAsPrerequisites { get; set; }
     bool BrightListItemHighlighting { get; set; }
     HighlightColor DefaultHighlightColor { get; }
+    HighlightColor OptionalUpgradeColor { get; set; }
     UiTheme UiTheme { get; set; }
 
     // DEBUGGING

--- a/BisBuddy/Services/Configuration/ConfigurationService.cs
+++ b/BisBuddy/Services/Configuration/ConfigurationService.cs
@@ -42,12 +42,14 @@ namespace BisBuddy.Services.Configuration
             this.jsonSerializerService = jsonSerializerService;
             configuration = this.configurationLoaderService.LoadConfig();
             configuration.DefaultHighlightColor.OnColorChange += handleDefaultHighlightColorChange;
+            configuration.OptionalUpgradeColor.OnColorChange += handleOptionalUpgradeColorChange;
             configuration.UiTheme.PropertyChanged += handleUiThemePropertyChange;
         }
 
         public void Dispose()
         {
             configuration.DefaultHighlightColor.OnColorChange -= handleDefaultHighlightColorChange;
+            configuration.OptionalUpgradeColor.OnColorChange -= handleOptionalUpgradeColorChange;
             configuration.UiTheme.PropertyChanged -= handleUiThemePropertyChange;
         }
 
@@ -150,6 +152,12 @@ namespace BisBuddy.Services.Configuration
             set => updateConfigProperty(cfg => cfg.AnnotateTooltips, value, affectsAssignments: false);
         }
 
+        public bool HighlightOptionalUpgrades
+        {
+            get => configuration.HighlightOptionalUpgrades;
+            set => updateConfigProperty(cfg => cfg.HighlightOptionalUpgrades, value, affectsAssignments: false);
+        }
+
         public bool AutoCompleteItems
         {
             get => configuration.AutoCompleteItems;
@@ -208,6 +216,17 @@ namespace BisBuddy.Services.Configuration
             get => configuration.DefaultHighlightColor;
         }
 
+        public HighlightColor OptionalUpgradeColor
+        {
+            get => configuration.OptionalUpgradeColor;
+            set
+            {
+                configuration.OptionalUpgradeColor.OnColorChange -= handleOptionalUpgradeColorChange;
+                value.OnColorChange += handleOptionalUpgradeColorChange;
+                updateConfigProperty(cfg => cfg.OptionalUpgradeColor, value, affectsAssignments: false);
+            }
+        }
+
         public UiTheme UiTheme
         {
             get => configuration.UiTheme;
@@ -229,6 +248,12 @@ namespace BisBuddy.Services.Configuration
         }
 
         private void handleDefaultHighlightColorChange()
+        {
+            configurationLoaderService.ScheduleConfigSave(configuration);
+            triggerConfigurationChange(affectsAssignments: false);
+        }
+
+        private void handleOptionalUpgradeColorChange()
         {
             configurationLoaderService.ScheduleConfigSave(configuration);
             triggerConfigurationChange(affectsAssignments: false);

--- a/BisBuddy/Services/OptionalUpgradeService.cs
+++ b/BisBuddy/Services/OptionalUpgradeService.cs
@@ -1,0 +1,152 @@
+using BisBuddy.Gear;
+using BisBuddy.Services.Configuration;
+using BisBuddy.Items;
+using Dalamud.Plugin.Services;
+using FFXIVClientStructs.FFXIV.Client.UI.Misc;
+using Lumina.Excel.Sheets;
+using Microsoft.Extensions.Hosting;
+using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace BisBuddy.Services
+{
+    public interface IOptionalUpgradeService : IHostedService
+    {
+        HighlightColor? GetUpgradeColor(uint itemId);
+    }
+
+    public class OptionalUpgradeService(
+        IDataManager dataManager,
+        IConfigurationService configurationService,
+        IInventoryItemsService inventoryItemsService,
+        IItemDataService itemDataService,
+        IClientState clientState) : IOptionalUpgradeService
+    {
+        private readonly IDataManager dataManager = dataManager;
+        private readonly IConfigurationService configurationService = configurationService;
+        private readonly IInventoryItemsService inventoryItemsService = inventoryItemsService;
+        private readonly IItemDataService itemDataService = itemDataService;
+        private readonly IClientState clientState = clientState;
+
+        // Job ID -> GearpieceType -> List of iLvls (Top 1 or 2)
+        private readonly Dictionary<byte, Dictionary<GearpieceType, List<uint>>> bestOwnedItems = [];
+        private DateTime lastUpdate = DateTime.MinValue;
+
+        public Task StartAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        public Task StopAsync(CancellationToken cancellationToken)
+        {
+            return Task.CompletedTask;
+        }
+
+        private void UpdateBestOwnedItems()
+        {
+            if ((DateTime.Now - lastUpdate).TotalSeconds < 5) return; // Throttling
+            lastUpdate = DateTime.Now;
+
+            bestOwnedItems.Clear();
+            var items = inventoryItemsService.InventoryItems;
+            
+            // Pre-fetch all jobs once
+            var jobs = dataManager.GetExcelSheet<ClassJob>().Where(j => j.RowId > 0).ToList();
+
+            foreach (var invItem in items)
+            {
+                var itemRow = dataManager.GetExcelSheet<Item>().GetRowOrDefault(invItem.ItemId);
+                if (itemRow == null || itemRow.Value.LevelItem.RowId == 0) continue;
+
+                var type = itemDataService.GetItemGearpieceType(invItem.ItemId);
+                if (type == GearpieceType.None) continue;
+
+                var ilvl = itemRow.Value.LevelItem.RowId;
+                var classJobCat = itemRow.Value.ClassJobCategory.Value;
+
+                foreach (var job in jobs)
+                {
+                    if (!IsJobInCategory((byte)job.RowId, classJobCat)) continue;
+
+                    if (!bestOwnedItems.TryGetValue((byte)job.RowId, out var jobMap))
+                    {
+                        jobMap = [];
+                        bestOwnedItems[(byte)job.RowId] = jobMap;
+                    }
+
+                    if (!jobMap.TryGetValue(type, out var ilvls))
+                    {
+                        ilvls = [];
+                        jobMap[type] = ilvls;
+                    }
+
+                    ilvls.Add(ilvl);
+                    ilvls.Sort((a, b) => b.CompareTo(a)); // Descending
+                    
+                    // We only care about the top 2 for rings, top 1 for everything else
+                    int maxCount = (type == GearpieceType.Finger) ? 2 : 1;
+                    if (ilvls.Count > maxCount)
+                    {
+                        ilvls.RemoveAt(maxCount);
+                    }
+                }
+            }
+        }
+
+        public HighlightColor? GetUpgradeColor(uint itemId)
+        {
+            if (!configurationService.HighlightOptionalUpgrades) return null;
+            if (!clientState.IsLoggedIn) return null;
+
+            UpdateBestOwnedItems();
+
+            var itemRow = dataManager.GetExcelSheet<Item>().GetRowOrDefault(itemId);
+            if (itemRow == null || itemRow.Value.LevelItem.RowId == 0) return null;
+
+            var type = itemDataService.GetItemGearpieceType(itemId);
+            if (type == GearpieceType.None) return null;
+
+            var classJobCat = itemRow.Value.ClassJobCategory.Value;
+            if (classJobCat.RowId == 0) return null;
+
+            var lootILvl = itemRow.Value.LevelItem.RowId;
+
+            // Check if this item is an upgrade for any job that can wear it
+            foreach (var (jobId, jobMap) in bestOwnedItems)
+            {
+                if (!IsJobInCategory(jobId, classJobCat)) continue;
+
+                if (!jobMap.TryGetValue(type, out var ilvls))
+                {
+                    return configurationService.OptionalUpgradeColor;
+                }
+
+                int requiredCount = (type == GearpieceType.Finger) ? 2 : 1;
+                if (ilvls.Count < requiredCount || lootILvl > ilvls.Min())
+                {
+                    return configurationService.OptionalUpgradeColor;
+                }
+            }
+
+            return null;
+        }
+
+        private bool IsJobInCategory(byte jobId, ClassJobCategory category)
+        {
+            // Simple check by looking at the ClassJobCategory boolean fields
+            // FFXIV stores these as booleans. We can use Lumina's property access.
+            var propName = dataManager.GetExcelSheet<ClassJob>().GetRowOrDefault(jobId)?.Abbreviation.ToString();
+            if (string.IsNullOrEmpty(propName)) return false;
+
+            var propInfo = typeof(ClassJobCategory).GetProperty(propName, System.Reflection.BindingFlags.IgnoreCase | System.Reflection.BindingFlags.Public | System.Reflection.BindingFlags.Instance);
+            if (propInfo != null)
+            {
+                return (bool)(propInfo.GetValue(category) ?? false);
+            }
+            return false;
+        }
+    }
+}

--- a/BisBuddy/Ui/Renderers/Tabs/Config/HighlightingSettingsTab.cs
+++ b/BisBuddy/Ui/Renderers/Tabs/Config/HighlightingSettingsTab.cs
@@ -1,6 +1,7 @@
 using BisBuddy.Resources;
 using BisBuddy.Services.Configuration;
 using BisBuddy.Ui.Renderers.Components;
+using BisBuddy.Gear;
 using Dalamud.Bindings.ImGui;
 using Dalamud.Interface.Utility.Raii;
 using Dalamud.Interface.Windowing;
@@ -101,12 +102,29 @@ namespace BisBuddy.Ui.Renderers.Tabs.Config
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip(Resource.HighlightMarketboardHelp);
 
-            // ITEM TOOLTIPS
             var annotateTooltips = configurationService.AnnotateTooltips;
             if (ImGui.Checkbox(Resource.HighlightItemTooltipsCheckbox, ref annotateTooltips))
                 configurationService.AnnotateTooltips = annotateTooltips;
             if (ImGui.IsItemHovered())
                 ImGui.SetTooltip(Resource.HighlightItemTooltipsHelp);
+
+            // OPTIONAL UPGRADES
+            var highlightOptionalUpgrades = configurationService.HighlightOptionalUpgrades;
+            if (ImGui.Checkbox("Highlight Optional Upgrades", ref highlightOptionalUpgrades))
+                configurationService.HighlightOptionalUpgrades = highlightOptionalUpgrades;
+            if (ImGui.IsItemHovered())
+                ImGui.SetTooltip("Highlight items that are an upgrade to your current active gearsets.");
+
+            using (ImRaii.Disabled(!highlightOptionalUpgrades))
+            {
+                UiComponents.DrawChildLConnector();
+                using (ImRaii.PushIndent(25.0f, scaled: false))
+                {
+                    var upgradeColor = configurationService.OptionalUpgradeColor.BaseColor;
+                    if (ImGui.ColorEdit4("Optional Upgrade Color", ref upgradeColor, ImGuiColorEditFlags.NoInputs | ImGuiColorEditFlags.AlphaPreviewHalf))
+                        configurationService.OptionalUpgradeColor = new HighlightColor(upgradeColor);
+                }
+            }
         }
 
         public void PreDraw() { }


### PR DESCRIPTION
Implemented a new fallback highlight system to visually flag gear pieces that offer an Item Level upgrade over the user's highest equipped gearsets. If you're running the latest alliance raid while not all your jobs are BiS, you can still get a visual cue for what items give you value and what to pass.

- Added OptionalUpgradeService to calculate and compare Item Levels against current jobs.
- Integrated seamless config toggles and custom color pickers into \HighlightingSettingsTab\.
- Hooked the upgrade logic into ItemDetailService (Tooltips), NeedGreedService (Loot), ShopExchangeService (Vendors), and ContainerService (Coffers).
- Fixed a bug with shops passing HQ modifier Item IDs by automatically normalizing them before lookup.